### PR TITLE
chore: CI ジョブを拡張 (整合性 + セキュリティスキャン)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,11 @@ jobs:
           go-version-file: core/go.mod
           cache: false
 
-      # `go mod tidy` 実行後に go.mod / go.sum が変更されないことを検証する。
-      # 不整合がある場合 (依存追加忘れ、未使用依存の残置など) は CI を fail させる。
-      - name: Run go mod tidy
-        run: go mod tidy
-
+      # Go 1.23+ の `go mod tidy -diff` を使い、go.mod / go.sum に差分が出る場合は非ゼロ終了する。
+      # この方式なら go.sum 非存在時 (依存ゼロ) でも安定して判定できる。
+      # 不整合 (依存追加忘れ、未使用依存の残置など) は CI を fail させる。
       - name: Verify go.mod and go.sum are tidy
-        run: git diff --exit-code -- go.mod go.sum
+        run: go mod tidy -diff
 
   markdown-format:
     name: Markdown format check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: CI
 
-# 最小 CI (M0.1 時点):
-# - core/ の Go ビルド・テスト (race) ・カバレッジ・vet
-# - リポジトリ全体の Markdown フォーマットチェック (prettier)
+# CI ジョブ:
+# - core-go: core/ の Go ビルド・テスト (race) ・カバレッジ・vet
+# - markdown-format: リポジトリ全体の Markdown フォーマットチェック (prettier)
+# - go-mod-tidy-check: core/go.mod / go.sum が `go mod tidy` 後と一致すること
+# - rulesync-drift-check: .rulesync/ 変更時に `make rulesync` の生成物が最新であること
 #
 # 後続マイルストーンで追加予定:
 # - golangci-lint (M0.2 以降、Lint 強化)
 # - examples/go-react/{backend,frontend} の job (実装着手時)
 # - examples/kotlin-nextjs/{backend,frontend} の job (実装着手時)
-# - rulesync drift check (.rulesync/ 変更時の生成物再生成チェック)
 
 on:
   push:
@@ -34,7 +35,7 @@ jobs:
         with:
           go-version-file: core/go.mod
           # core/go.sum はまだ存在しない (標準ライブラリのみ) ため cache-dependency-path は省略。
-          # 依存追加 (M0.2 以降) で go.sum が生成された後にキャッシュが有効化される。
+          # 依存追加で go.sum が生成された後にキャッシュが有効化される。
           cache: false
 
       - name: Build
@@ -54,6 +55,30 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+  go-mod-tidy-check:
+    name: core/ go mod tidy check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: core/go.mod
+          cache: false
+
+      # `go mod tidy` 実行後に go.mod / go.sum が変更されないことを検証する。
+      # 不整合がある場合 (依存追加忘れ、未使用依存の残置など) は CI を fail させる。
+      - name: Run go mod tidy
+        run: go mod tidy
+
+      - name: Verify go.mod and go.sum are tidy
+        run: git diff --exit-code -- go.mod go.sum
+
   markdown-format:
     name: Markdown format check
     runs-on: ubuntu-latest
@@ -64,9 +89,35 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
-      # prettier のバージョンは ルート Makefile の PRETTIER_VERSION と合わせる。
-      # .prettierignore でリポジトリ管理外 (アーカイブ/ 等) を除外済み。
+      # prettier のバージョンはルート Makefile の PRETTIER_VERSION と合わせる。
+      # .prettierignore でリポジトリ管理外を除外済み。
       - name: Prettier check
         run: npx -y prettier@3.8.3 --check .
+
+  rulesync-drift-check:
+    name: rulesync drift check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # .rulesync/ を正本に各 AI ツール向け生成物 (.claude/, .codex/, AGENTS.md, CLAUDE.md 等) を再生成し、
+      # コミット済みのファイルと差分が出ないことを検証する。
+      # 「.rulesync/ を編集したのに make rulesync を忘れている」状態を防ぐ。
+      - name: Regenerate rulesync outputs
+        run: make rulesync
+
+      - name: Verify generated files are up-to-date
+        run: |
+          if ! git diff --exit-code; then
+            echo ""
+            echo "::error::.rulesync/ の変更が反映されていません。ローカルで 'make rulesync' を実行してから push してください。"
+            exit 1
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,7 +64,8 @@ jobs:
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 
       - name: Run gosec
-        run: gosec ./...
+        # $GOPATH/bin が PATH に入る前提に依存しないよう、絶対パスで呼ぶ。
+        run: $(go env GOPATH)/bin/gosec ./...
 
   secret-detection:
     name: secret detection (gitleaks)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,6 +42,9 @@ jobs:
   gosec:
     name: core/ gosec
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,12 +55,13 @@ jobs:
           go-version-file: core/go.mod
           cache: false
 
-      # gosec 公式 Action を使用。CVE / 脆弱性パターンを検出した場合 fail。
-      # SARIF を出して Security tab に反映することもできるが、現状は最小構成。
+      # gosec 公式 Action。CVE / 脆弱性パターンを検出した場合 fail。
+      # @v2 は major tag 固定 (mutable)。供給網リスクをさらに下げたい場合は commit SHA pin + Dependabot 運用に移行する (将来課題)。
+      # working-directory が反映されないため、args で core/... を明示的に指定する。
       - name: Run gosec
-        uses: securego/gosec@master
+        uses: securego/gosec@v2
         with:
-          args: ./...
+          args: ./core/...
         env:
           GOMODCACHE: /tmp/gomodcache
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,19 +52,19 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
+          # core/go.mod 由来の Go バージョンをインストール。
+          # gosec 公式 Action (securego/gosec@v2.26.1) は内蔵 Go が固定で go.mod の要求 (例 1.26.2) と合わない場合があるため、
+          # Action ではなく go install + 直接実行に切り替えている。
           go-version-file: core/go.mod
           cache: false
 
-      # gosec 公式 Action。CVE / 脆弱性パターンを検出した場合 fail。
-      # securego/gosec は major tag (@v2) を提供しないため patch tag を直接固定する。
-      # 供給網リスクをさらに下げたい場合は commit SHA pin + Dependabot 運用に移行する (将来課題)。
-      # working-directory が反映されないため、args で core/... を明示的に指定する。
+      # gosec を go install で導入 (Action 内蔵 Go に縛られないため)。
+      # バージョンは go install 用に明示固定。@latest は使わない (供給網のため)。
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+
       - name: Run gosec
-        uses: securego/gosec@v2.26.1
-        with:
-          args: ./core/...
-        env:
-          GOMODCACHE: /tmp/gomodcache
+        run: gosec ./...
 
   secret-detection:
     name: secret detection (gitleaks)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,10 +56,11 @@ jobs:
           cache: false
 
       # gosec 公式 Action。CVE / 脆弱性パターンを検出した場合 fail。
-      # @v2 は major tag 固定 (mutable)。供給網リスクをさらに下げたい場合は commit SHA pin + Dependabot 運用に移行する (将来課題)。
+      # securego/gosec は major tag (@v2) を提供しないため patch tag を直接固定する。
+      # 供給網リスクをさらに下げたい場合は commit SHA pin + Dependabot 運用に移行する (将来課題)。
       # working-directory が反映されないため、args で core/... を明示的に指定する。
       - name: Run gosec
-        uses: securego/gosec@v2
+        uses: securego/gosec@v2.26.1
         with:
           args: ./core/...
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,80 @@
+name: Security
+
+# セキュリティスキャン:
+# - govulncheck: 標準ライブラリ + 依存ライブラリの既知脆弱性検出
+# - gosec: Go ソースコードの静的セキュリティ解析
+# - secret-detection: gitleaks による秘密情報の混入検知
+#
+# 後続マイルストーンで追加予定:
+# - dockerfile-security (hadolint) ... Docker 化 (M0.2 以降) で導入
+# - license-check ... 外部依存追加時に導入
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: core/ govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: core/go.mod
+          cache: false
+
+      # 標準ライブラリのみでも Go バージョンに紐づく既知脆弱性は検出される。
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: core/go.mod
+          work-dir: core
+          # CVE が出た場合は CI を fail させる (デフォルト挙動)。
+
+  gosec:
+    name: core/ gosec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: core/go.mod
+          cache: false
+
+      # gosec 公式 Action を使用。CVE / 脆弱性パターンを検出した場合 fail。
+      # SARIF を出して Security tab に反映することもできるが、現状は最小構成。
+      - name: Run gosec
+        uses: securego/gosec@master
+        with:
+          args: ./...
+        env:
+          GOMODCACHE: /tmp/gomodcache
+
+  secret-detection:
+    name: secret detection (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # gitleaks-action は PR コメントを書く機能を持つが、本リポジトリでは使わないため pull-requests 権限は付与しない。
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # gitleaks は git history を全走査するため、コミット履歴を fetch する。
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/internal/server/server.go
+++ b/core/internal/server/server.go
@@ -7,10 +7,15 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/mktkhr/id-core/core/internal/config"
 	"github.com/mktkhr/id-core/core/internal/health"
 )
+
+// readHeaderTimeout はリクエストヘッダ読み取り全体のタイムアウト。
+// Slowloris 攻撃 (CWE-400) 対策。後続マイルストーンで他のタイムアウト (ReadTimeout / WriteTimeout / IdleTimeout) も追加する。
+const readHeaderTimeout = 10 * time.Second
 
 // New は cfg に従って *http.Server を構築して返す。
 //
@@ -22,7 +27,8 @@ func New(cfg *config.Config) *http.Server {
 	mux.HandleFunc("GET /health", health.Handler)
 
 	return &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Port),
-		Handler: mux,
+		Addr:              fmt.Sprintf(":%d", cfg.Port),
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 }


### PR DESCRIPTION
## Summary

CI に以下のジョブを追加。

### `.github/workflows/ci.yml` (整合性チェック系)

- **go-mod-tidy-check**: `go mod tidy -diff` (Go 1.23+) で `core/go.mod` / `go.sum` に差分が出ないことを検証
- **rulesync-drift-check**: `make rulesync` 実行後に生成物 (`.claude/`, `.codex/`, `AGENTS.md`, `CLAUDE.md` 等) が変化しないことを検証

### `.github/workflows/security.yml` (新規)

- **govulncheck**: Go 標準ライブラリ + 依存ライブラリの既知脆弱性検出 (`golang/govulncheck-action`)
- **gosec**: Go ソースコードの静的セキュリティ解析 (`go install` 経由でバージョン固定、scan 対象は `core/...`)
- **secret-detection**: gitleaks による秘密情報の混入検知 (`gitleaks/gitleaks-action`、git history 全走査)

### 既存ジョブの修正

- `markdown-format` ジョブの Node.js を 22 → 24 (Active LTS) に更新

## Action のバージョン pinning 方針

Third-party Action は major タグ (v1 / v2) 系で固定。可変ブランチ参照 (master / main) は使用しない。
将来、供給網リスクをさらに下げるため commit SHA pinning + Dependabot 連携への移行を検討する (本 PR では未対応、後続改善事項)。

## 後続予定 (本 PR には含めない)

- golangci-lint (M0.2 以降、`go vet` から強化)
- examples/go-react/{backend,frontend} 用ジョブ (実装着手時)
- examples/kotlin-nextjs/{backend,frontend} 用ジョブ (実装着手時)
- dockerfile-security (Docker 化 = M0.2 以降)
- license-check (外部依存追加時)
- Action の commit SHA pinning + Dependabot

## 事前ローカル検証

- `go mod tidy -diff` 後 差分なし
- `make rulesync` 後 リポジトリに drift なし
- `gosec ./...` ローカル実行で Issues=0 (G112 Slowloris 対策で `ReadHeaderTimeout` を server.go に追加済み)
- govulncheck / gitleaks は Action 提供のため CI 上で初回確認

## Test plan

- [ ] PR 上で 全ジョブ (`core-go`, `markdown-format`, `go-mod-tidy-check`, `rulesync-drift-check`, `govulncheck`, `gosec`, `secret-detection`) が green になる
- [ ] gitleaks が誤検知して fail しないこと (誤検知時は `.gitleaksignore` で個別対処)

## Codex レビュー履歴

- 1st: HIGH 1 (Action のブランチ参照固定) / MEDIUM 2 / LOW 1 → 修正
- 2nd: CRITICAL 0 / HIGH 0 / MEDIUM 1 (commit SHA pinning、後続改善として保留) / LOW 0 → ゲート通過