### PR TITLE
docs:📝 設計 #7 実装プロンプト 3 件を生成 (自己完結型)

### DIFF
--- a/docs/specs/7/prompts/P1_01_core_logger_apperror.md
+++ b/docs/specs/7/prompts/P1_01_core_logger_apperror.md
@@ -37,6 +37,8 @@
 2. `core/go.mod` に `github.com/google/uuid` v1.6+ を追加する**前にユーザーへ承認を求める** (バージョンも提示)。承認後に `go get github.com/google/uuid@v1.6.0` を実行
 3. `make -C core build && make -C core test` がベースラインで pass することを確認
 
+> **Codex レビュー対象外**: ステップ 0 はブランチ作成・依存追加承認・ベースライン確認のみで Go コード変更を伴わない。レビューはステップ 1 以降で実施する。
+
 ### ステップ 1: `core/internal/apperror/` 実装
 
 `apperror` は `logger` の redact 連携で参照されるため先に実装する。
@@ -79,12 +81,14 @@
 4. **Codex レビューを実行**
 5. 指摘を対応してから次のステップへ
 
-### ステップ 6: 全体テスト + ベースラインの確認
+### ステップ 6: 全体テスト + ベースラインの確認 + 最終 Codex レビュー
 
 1. `make -C core build && make -C core test && make -C core lint` 全件 pass
 2. `grep -rn "log\.Fatal" core/` の出力が**増えていない**ことを確認 (本 Issue では cmd/core/main.go の既存利用は temporally 残してよい。完全排除は P2 で行う)
 3. `grep -rn "uuid\.New[^V]" core/` の出力が 0 件 (UUID v4 が混入していない)
-4. PR 作成 → `/pr-codex-review {番号}` でゲート通過 → ユーザー承認 → マージ
+4. PR 作成 (`gh pr create` with `--assignee` + `--label`)
+5. **`/pr-codex-review {PR 番号}` で Codex に PR 全体 (差分 + description) をレビューさせる**。これが本フェーズの最終 Codex レビュー (絶対ルール「Codex レビュー必須」を満たす全体検査)
+6. ゲート通過 (CRITICAL=0 / HIGH=0 / MEDIUM<3) → ユーザー承認 → マージ
 
 ## 実装コンテキスト
 

--- a/docs/specs/7/prompts/P1_01_core_logger_apperror.md
+++ b/docs/specs/7/prompts/P1_01_core_logger_apperror.md
@@ -1,0 +1,435 @@
+# P1: core/internal/logger + core/internal/apperror パッケージ実装
+
+- 対応 Issue: #12 (【実装】M0.2 ログ・エラー基盤: logger + apperror パッケージ)
+- 元要求: #7
+- 親設計書: `docs/specs/7/index.md`
+- マイルストーン: M0.2 (Phase 0: スパイク)
+
+## 絶対ルール
+
+- **コードベース探索禁止**: Grep, Glob, Read による既存コードの探索的な読み取りを行わない
+- **Explore エージェント起動禁止**: サブエージェントによるコードベース調査を行わない
+- 実装に必要な情報は全て、以下の context ファイルとこのプロンプト内に記載済み
+- context に記載がなく実装判断できない場合は、探索ではなく**ユーザーに質問**すること
+- 変更対象ファイルの直接の Read / Edit のみ許可 (探索目的の Read は禁止)
+- **Codex レビューをスキップしない**: 各作業ステップに Codex レビューが含まれている。レビューを受けずに次のステップに進むことは禁止
+- **完了条件のタスク化**: 作業開始前に「完了条件」セクションの各項目を TaskCreate で登録し、各ステップ完了時に TaskUpdate で状態を更新すること。タスク化せずに作業を開始することは禁止
+
+### プロジェクト固有の禁止事項 (恒久ルール)
+
+- **UUID v4 禁止**: `request_id` / `event_id` / DB 主キーいずれも **UUID v7 のみ** を使う。Go では `github.com/google/uuid` v1.6 以上の `uuid.NewV7()` を使う。`uuid.New()` / `uuid.NewRandom()` (= v4) は呼ばない
+- **`log.Fatal*` 禁止**: `core/` 配下で `log.Fatal` / `log.Fatalf` / `log.Fatalln` を使わない。本 Issue では使用箇所はないが、新規追加禁止
+- **`time.Local = time.UTC` 禁止**: プロセス全体への副作用となるため使わない。代わりに `slog.NewJSONHandler` の `ReplaceAttr` フックで `time.Time` を `t.UTC().Format(time.RFC3339Nano)` に変換する
+- **redact 部分一致禁止**: deny-list キーは **case-insensitive かつ完全一致** で照合する。`accessusername` のようなフィールドが `access_token` の部分一致で誤検出されてはならない
+- **Domain 層ログ禁止**: 本 Issue では Domain 層の実装はないが、後続 Issue でロガーを呼ぶのは middleware / handler / infrastructure 層のみ。logger パッケージが提供する API は context 経由で `request_id` / `event_id` を取得する設計とする
+- **依存追加の独断禁止**: `go.mod` に新規依存を追加する場合 (例: `github.com/google/uuid`) はユーザーに事前承認を取る。バージョンも明示
+
+### コミット時の禁止事項
+
+- コミットメッセージに `Co-Authored-By:` trailer を入れない (恒久ルール)
+- main ブランチへ直接 push しない (feature ブランチ + PR + Codex レビュー必須、`.rulesync/rules/pr-review-policy.md` 準拠)
+
+## 作業ステップ (この順序で実行すること)
+
+### ステップ 0: 前提セットアップ
+
+1. 作業ブランチ `feature/m0.2-impl-logger-apperror` を `main` から切る
+2. `core/go.mod` に `github.com/google/uuid` v1.6+ を追加する**前にユーザーへ承認を求める** (バージョンも提示)。承認後に `go get github.com/google/uuid@v1.6.0` を実行
+3. `make -C core build && make -C core test` がベースラインで pass することを確認
+
+### ステップ 1: `core/internal/apperror/` 実装
+
+`apperror` は `logger` の redact 連携で参照されるため先に実装する。
+
+1. テストを先に書く: `apperror_test.go` で T-47〜T-52 を実装 (失敗確認)
+2. 実装: `apperror.go` (CodedError 型 / `New` / `WithDetails` / `Unwrap`) と `response.go` (F-7 基本形 JSON シリアライザ)
+3. `make -C core lint test` が pass することを確認
+4. **Codex レビューを実行** (コマンドは末尾)
+5. 指摘を対応してから次のステップへ
+
+### ステップ 2: `core/internal/logger/` 実装 (基盤)
+
+1. テストを先に書く: `logger_test.go` で T-1〜T-5 (初期化・フォーマット・time フィールド・副作用) を実装 (失敗確認)
+2. 実装: `logger.go` (薄い独自インターフェース) + `format.go` (`CORE_LOG_FORMAT=json|text` 切替、`ReplaceAttr` で UTC 強制)
+3. `make -C core lint test` が pass
+4. **Codex レビューを実行**
+5. 指摘を対応してから次のステップへ
+
+### ステップ 3: `core/internal/logger/context.go` (context 伝播)
+
+1. テストを先に書く: `context_test.go` で T-6〜T-9 を実装 (失敗確認)
+2. 実装: `WithRequestID(ctx, id)` / `RequestIDFrom(ctx)` / `WithEventID(ctx, id)` / `EventIDFrom(ctx)`、logger の `Info` 等が context から自動で `request_id` / `event_id` を attr 化
+3. `make -C core lint test` が pass
+4. **Codex レビューを実行**
+5. 指摘を対応してから次のステップへ
+
+### ステップ 4: `core/internal/logger/redact.go` (deny-list redactor)
+
+1. テストを先に書く: `redact_test.go` で T-10〜T-18 を実装 (失敗確認)
+2. 実装: deny-list 完全リスト (本プロンプトの「設計仕様 / redact 規約」参照)、HTTP ヘッダ照合 (case-insensitive)、JSON body / map / 配列の再帰走査、完全一致のみ (部分一致禁止)、`[REDACTED]` 固定値置換
+3. `make -C core lint test` が pass
+4. **Codex レビューを実行**
+5. 指摘を対応してから次のステップへ
+
+### ステップ 5: `core/internal/logger/fallback.go` (出力失敗時フォールバック)
+
+1. テストを先に書く: `fallback_test.go` で T-19〜T-21 を実装 (失敗確認)
+2. 実装: stdout writer エラー時に stderr へフォールバック書き込み、`sync/atomic` で drop counter を保持、エクスポートする `DropCount() int64` を提供 (M1.x のメトリクス連携で利用)
+3. `make -C core lint test` が pass
+4. **Codex レビューを実行**
+5. 指摘を対応してから次のステップへ
+
+### ステップ 6: 全体テスト + ベースラインの確認
+
+1. `make -C core build && make -C core test && make -C core lint` 全件 pass
+2. `grep -rn "log\.Fatal" core/` の出力が**増えていない**ことを確認 (本 Issue では cmd/core/main.go の既存利用は temporally 残してよい。完全排除は P2 で行う)
+3. `grep -rn "uuid\.New[^V]" core/` の出力が 0 件 (UUID v4 が混入していない)
+4. PR 作成 → `/pr-codex-review {番号}` でゲート通過 → ユーザー承認 → マージ
+
+## 実装コンテキスト
+
+```
+CONTEXT_DIR="docs/context"
+```
+
+実装時に参照する context ファイル (これだけで足りるよう設計済み):
+
+- `${CONTEXT_DIR}/app/architecture.md` (id-core 全体像、不読でも実装可)
+- `${CONTEXT_DIR}/backend/conventions.md` (Go 1.22+ 規約、`internal/<feature>/` 配置、Makefile 規約)
+- `${CONTEXT_DIR}/backend/patterns.md` (httptest パターン、`t.Setenv` 制約、外部テストパッケージ命名)
+
+設計書: `docs/specs/7/index.md`
+
+適用範囲: `core/internal/logger/` および `core/internal/apperror/` のみ (新規)
+
+## 前提条件
+
+- M0.1 (Issue #1, #2) 完了済み: `core/cmd/core/main.go` / `core/internal/{config,server,health}/` が存在し、`make -C core build && make test && make lint` がベースラインで pass する
+- 本 Issue (#12) 完了後に Issue #13 (middleware + server 統合) に着手可能になる
+- Issue #14 (契約テスト + context 更新) は #12 + #13 完了後
+
+## 不明点ハンドリング
+
+- 矛盾・欠落・未定義がある場合は作業を止める
+- 勝手な推測で実装を進めない
+- 質問時は: 止まっている作業単位 / 判断が必要な論点 / 選択肢を整理
+- 特に以下が判明した時点で**即停止してユーザーに質問**する:
+  - `github.com/google/uuid` のバージョン選定で迷う
+  - `slog.NewJSONHandler` の `ReplaceAttr` で UTC 変換できないケース
+  - redact のキー照合で部分一致が必要に見えるケース
+  - 設計書 (`docs/specs/7/index.md`) と本プロンプトに矛盾を発見
+
+## タスク境界
+
+### 本プロンプトで実装する範囲
+
+- `core/internal/logger/` の全ファイル (`logger.go` / `context.go` / `format.go` / `redact.go` / `fallback.go` + 各 `_test.go`)
+- `core/internal/apperror/` の全ファイル (`apperror.go` / `response.go` / `apperror_test.go`)
+- `core/go.mod` への `github.com/google/uuid` 追加 (ユーザー承認後)
+- 上記ファイルの単体テスト T-1〜T-21 (logger 21 ケース) + T-47〜T-52 (apperror 6 ケース) = **計 27 ケース**
+
+### 本プロンプトでは実装しない範囲
+
+- HTTP middleware (`internal/middleware/`) → P2 (Issue #13)
+- `server.go` の middleware チェーン組込 → P2
+- `cmd/core/main.go` の `log.Fatal` 全廃 → P2
+- F-16 ログスキーマ契約テスト → P3 (Issue #14)
+- `docs/context/` 4 ファイルの更新 → P3
+- `core/Makefile` の lint で grep 検査追加 → P3
+- `core/README.md` の規約入口段落追加 → P3
+
+## 設計仕様
+
+### 関連要件 (F-N) の引用
+
+| ID   | 内容                                                                                                                                                                                                                                   |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F-1  | 構造化ログが標準出力に JSON Lines 形式で出力される (本番想定モード)。クライアント由来文字列はすべて JSON エンコーダ経由で出力し、改行・制御文字によるログインジェクションを防ぐ                                                        |
+| F-2  | 開発時用に人間可読フォーマットへ切り替えるモードが用意されている (環境変数 `CORE_LOG_FORMAT=json\|text`、デフォルト `json`)                                                                                                            |
+| F-3  | HTTP 経路で発生する全ログレコードに `request_id` を必須付与する。最低限のフィールド: `time` (RFC3339Nano UTC) / `level` (DEBUG/INFO/WARN/ERROR) / `msg` / `request_id` / `method` / `path` / `status` / `duration_ms` (アクセスログ系) |
+| F-4  | HTTP 経路外のログレコードには HTTP 由来の `request_id` を入れず、代わりに `event_id` (起動毎・ジョブ毎に発番される一意 ID) を必須付与する                                                                                              |
+| F-7  | 内部 API のエラーレスポンス JSON 形式は `{ "code": string, "message": string, "details"?: object, "request_id": string }`。`details` は object / array に限定                                                                          |
+| F-13 | シークレットはログ出力時に redact される。完全リストは下記 Q8 採用値                                                                                                                                                                   |
+| F-14 | Domain 層でロガーを直接呼ばない。logger は `context.Context` から `request_id` / `event_id` を取得して付与                                                                                                                             |
+
+### 関連論点 (Q-N / D-N) の決定値
+
+| ID  | 決定                                                                                                                                                                                                           |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1  | ロガー実装: **`log/slog` (Go 標準)**                                                                                                                                                                           |
+| Q2  | フォーマット切替: **`CORE_LOG_FORMAT=json\|text`** (デフォルト `json`)                                                                                                                                         |
+| Q3  | 一意 ID 生成: **UUID v7** (v4 禁止、`github.com/google/uuid` v1.6+ の `uuid.NewV7()`)                                                                                                                          |
+| Q4  | `time` フォーマット: **RFC3339Nano (UTC、`Z` suffix 強制)**。`slog.NewJSONHandler` の `ReplaceAttr` で `t.UTC().Format(time.RFC3339Nano)` に変換 (`time.Local = time.UTC` の全プロセス副作用は禁止)            |
+| Q5  | 内部 API エラー JSON: F-7 基本形を **`internal/apperror/`** パッケージで実装                                                                                                                                   |
+| Q7  | ログレベル使い分け: DEBUG (本番無効、開発・調査) / INFO (業務イベント) / WARN (4xx) / ERROR (5xx・panic・予期しないエラー)                                                                                     |
+| Q8  | redact 完全リスト (下記参照)                                                                                                                                                                                   |
+| Q9  | ログ出力失敗時: **stderr フォールバック + atomic drop counter**。リクエスト処理は継続。drop counter は内部保持、外部公開は M1.x で                                                                             |
+| D2  | logger 公開 API: **薄い独自インターフェース** (`logger.Info(ctx, msg, ...args)` / `logger.Error(ctx, msg, err, ...args)`)。内部実装は `slog.Logger`、context から `request_id` / `event_id` を自動付与する責務 |
+
+### redact 規約 (Q8 完全一覧)
+
+| 適用面                  | 対象キー                                                                                                                                                                                                                          | 照合規則                                             |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| HTTP リクエストヘッダ   | `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`                                                                                                                                       | case-insensitive                                     |
+| JSON body / `details`   | `password`, `current_password`, `new_password`, `access_token`, `refresh_token`, `id_token`, `code`, `code_verifier`, `client_secret`, `assertion`, `client_assertion`, `private_key`, `secret`, `api_key`, `jwt`, `bearer_token` | case-insensitive かつ完全一致 / ネスト・配列再帰走査 |
+| query / form パラメータ | 同上 (body と同一リスト)                                                                                                                                                                                                          | case-insensitive かつ完全一致                        |
+| error chain メッセージ  | 同上 (文字列 fuzzy 検出は行わず、構造化フィールド経由でのみ redact)                                                                                                                                                               | キー一致のみ                                         |
+
+**redact 値**: 文字列 `[REDACTED]` 固定で置換。長さや存在情報を漏らさない (`****` のようなマスキング禁止)。
+
+### `internal/apperror/` 実装の詳細
+
+```go
+// apperror.go (実装の方向性。完全な署名は実装者が決めてよい)
+
+// CodedError は内部 API のエラーレスポンスを表す型。
+type CodedError struct {
+    code    string         // SCREAMING_SNAKE_CASE (例: "INVALID_PARAMETER")
+    message string         // 人間可読 (本スコープでは日本語、i18n は M3.3 以降)
+    details map[string]any // optional, object/array のみ。シークレット禁止 (redact 連携)
+    cause   error          // error chain (errors.Is / errors.As 互換)
+}
+
+// New は CodedError を新規作成する。
+func New(code, message string) *CodedError
+
+// WithDetails は details を付与した新しいインスタンスを返す (immutable)。
+func (e *CodedError) WithDetails(details map[string]any) *CodedError
+
+// Wrap は原因 error をラップして error chain を作る。
+func (e *CodedError) Wrap(cause error) *CodedError
+
+// Code / Message / Details ゲッター
+// Unwrap は errors.Is / errors.As 互換のために cause を返す。
+```
+
+```go
+// response.go (実装の方向性)
+
+// Response は F-7 基本形 JSON のシリアライズ用構造体。
+// HTTP middleware (P2) から呼び出されてレスポンスボディに書き込まれる。
+type Response struct {
+    Code      string         `json:"code"`
+    Message   string         `json:"message"`
+    Details   map[string]any `json:"details,omitempty"`
+    RequestID string         `json:"request_id"`
+}
+
+// ToResponse は CodedError を Response に変換する。
+// request_id は context から取得する責務は呼び出し側 (middleware) にある。
+func ToResponse(e *CodedError, requestID string) Response
+
+// WriteJSON は w に Response を JSON Lines として書き込み、Content-Type を設定する。
+// (P2 の middleware から呼ばれる)
+func WriteJSON(w http.ResponseWriter, status int, e *CodedError, requestID string) error
+```
+
+固定の `code` 値 (本 Issue で定義する最低限):
+
+- `INTERNAL_ERROR`: panic 時の固定 code (P2 の recover middleware で使用)
+- 他のコードは後続 Issue / マイルストーンで追加
+
+### `internal/logger/` 実装の詳細
+
+```go
+// logger.go (薄い独自インターフェース)
+
+// Logger は本プロジェクトのログ出力 API。
+// 内部実装は slog.Logger だが、context から request_id / event_id を自動付与する。
+type Logger struct {
+    // 内部 slog.Handler (JSON or Text)
+}
+
+func New(format Format, w io.Writer) *Logger // 主要コンストラクタ
+func Default() *Logger                        // CORE_LOG_FORMAT を読んで初期化
+
+func (l *Logger) Info(ctx context.Context, msg string, args ...any)
+func (l *Logger) Warn(ctx context.Context, msg string, args ...any)
+func (l *Logger) Error(ctx context.Context, msg string, err error, args ...any) // err 専用引数
+func (l *Logger) Debug(ctx context.Context, msg string, args ...any)
+```
+
+```go
+// context.go (context 伝播)
+
+type ctxKey struct{ name string }
+
+var (
+    requestIDKey = ctxKey{"request_id"}
+    eventIDKey   = ctxKey{"event_id"}
+)
+
+func WithRequestID(ctx context.Context, id string) context.Context
+func RequestIDFrom(ctx context.Context) string // 取れなければ空文字
+
+func WithEventID(ctx context.Context, id string) context.Context
+func EventIDFrom(ctx context.Context) string // 取れなければ空文字
+```
+
+```go
+// format.go (CORE_LOG_FORMAT 切替 + UTC ReplaceAttr)
+
+type Format int
+
+const (
+    FormatJSON Format = iota
+    FormatText
+)
+
+const envLogFormat = "CORE_LOG_FORMAT"
+
+func FormatFromEnv() (Format, error) // CORE_LOG_FORMAT を読む。invalid はエラー
+func newHandler(format Format, w io.Writer) slog.Handler // ReplaceAttr で time を UTC 化
+```
+
+```go
+// redact.go (deny-list redactor)
+
+const RedactedValue = "[REDACTED]"
+
+// HeaderKeysToRedact は HTTP リクエストヘッダの redact 対象 (case-insensitive)。
+var HeaderKeysToRedact = []string{
+    "Authorization",
+    "Cookie",
+    "Set-Cookie",
+    "Proxy-Authorization",
+    "X-Api-Key",
+    "X-Auth-Token",
+}
+
+// FieldKeysToRedact は body / query / form / details の redact 対象 (case-insensitive 完全一致)。
+var FieldKeysToRedact = []string{
+    "password",
+    "current_password",
+    "new_password",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "code",
+    "code_verifier",
+    "client_secret",
+    "assertion",
+    "client_assertion",
+    "private_key",
+    "secret",
+    "api_key",
+    "jwt",
+    "bearer_token",
+}
+
+// RedactHeaders は http.Header のディープコピーを作り、対象キーを [REDACTED] に置換する。
+func RedactHeaders(h http.Header) http.Header
+
+// RedactMap は map[string]any を再帰走査して対象キーを [REDACTED] に置換する (object/array)。
+// 元の map は変更しない (new map を返す)。
+func RedactMap(m map[string]any) map[string]any
+```
+
+```go
+// fallback.go (ログ出力失敗時)
+
+// FallbackWriter は writer を wrap し、書き込み失敗時に stderr へフォールバックする。
+// stderr も失敗した場合は drop count を atomic に増分する。
+type FallbackWriter struct {
+    primary io.Writer
+    drops   atomic.Int64
+}
+
+func NewFallbackWriter(primary io.Writer) *FallbackWriter
+func (w *FallbackWriter) Write(p []byte) (int, error) // ログ自身の書き込みは失敗を返さない (継続)
+func (w *FallbackWriter) DropCount() int64
+```
+
+## テスト観点
+
+### `internal/logger/` のテスト (T-1〜T-21)
+
+| #    | カテゴリ     | 観点                                                            | 期待                                                                               | 関連          |
+| ---- | ------------ | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------- |
+| T-1  | 正常系       | `CORE_LOG_FORMAT=json` (デフォルト) で初期化                    | `slog.NewJSONHandler` ベース、出力は 1 行 JSON で `time` / `level` / `msg` を含む  | F-1, Q1, Q2   |
+| T-2  | 正常系       | `CORE_LOG_FORMAT=text` で初期化                                 | `slog.NewTextHandler` ベース、出力は `key=value` 形式                              | F-2, Q2       |
+| T-3  | 異常系       | `CORE_LOG_FORMAT=invalid` で初期化                              | エラーが返る (`fmt.Errorf` で原因含む)                                             | F-2, Q2       |
+| T-4  | 正常系       | `time` フィールドのフォーマット                                 | `2026-05-02T01:00:00.123456789Z` 形式 (RFC3339Nano、UTC、`Z` suffix)               | F-3, Q4       |
+| T-5  | セキュリティ | プロセス全体への副作用がない                                    | ロガー初期化前後で `time.Local` が変化しない                                       | Q4            |
+| T-6  | 正常系       | `WithRequestID(ctx, "v7-uuid")` 後に `RequestIDFrom(ctx)`       | 元の値が取り出せる                                                                 | F-5, F-14     |
+| T-7  | 正常系       | `WithEventID(ctx, "v7-uuid")` 後に `EventIDFrom(ctx)`           | 元の値が取り出せる                                                                 | F-4, F-14     |
+| T-8  | 準正常系     | request_id を入れていない context から `RequestIDFrom(ctx)`     | 空文字 (panic しない)                                                              | F-14          |
+| T-9  | 正常系       | logger 経由でログ出力時に context から自動付与                  | `request_id` (HTTP 経路) または `event_id` (非 HTTP 経路) がログレコードに含まれる | F-3, F-4, D2  |
+| T-10 | セキュリティ | HTTP ヘッダ `Authorization: Bearer xxx` を redact               | `[REDACTED]` 置換                                                                  | F-13, Q8      |
+| T-11 | セキュリティ | HTTP ヘッダ `authorization: bearer xxx` (case 違い) を redact   | case-insensitive で `[REDACTED]` 置換                                              | F-13, Q8      |
+| T-12 | セキュリティ | JSON body `{"password": "secret"}` を redact                    | `password` 値が `[REDACTED]` 置換                                                  | F-13, Q8      |
+| T-13 | セキュリティ | ネストした JSON `{"outer": {"client_secret": "xxx"}}` を redact | 再帰走査で `client_secret` 値が `[REDACTED]`                                       | F-13, Q8      |
+| T-14 | セキュリティ | 配列内の JSON `{"creds": [{"access_token": "x"}]}` を redact    | 配列要素も走査して `access_token` 値が `[REDACTED]`                                | F-13, Q8      |
+| T-15 | セキュリティ | redact 対象キーの全 16 フィールドを網羅 (テーブル駆動)          | Q8 完全リスト全件が `[REDACTED]`                                                   | F-13, Q8      |
+| T-16 | セキュリティ | redact 対象キーの全 6 ヘッダを網羅                              | Q8 完全リスト 6 件が case-insensitive で `[REDACTED]`                              | F-13, Q8      |
+| T-17 | 準正常系     | redact 対象でないキー `username` は変換しない                   | 値はそのまま (部分一致禁止: `accessusername` は `access_token` に誤検知しない)     | F-13, Q8      |
+| T-18 | セキュリティ | redact 対象キーが存在しない場合の出力                           | 元の構造のまま `[REDACTED]` 置換は発生しない                                       | F-13          |
+| T-19 | 異常系       | stdout writer がエラーを返す状況をモックして再現                | リクエスト処理は継続 (panic しない)、stderr に最低限のフォールバック行が出力される | NFR可用性, Q9 |
+| T-20 | 異常系       | stdout / stderr 両方失敗する状況                                | 処理継続、drop counter が増加 (`atomic.LoadInt64` で確認)                          | NFR可用性, Q9 |
+| T-21 | 正常系       | 通常出力時の drop counter                                       | 0 のまま増加しない                                                                 | Q9            |
+
+### `internal/apperror/` のテスト (T-47〜T-52)
+
+| #    | カテゴリ     | 観点                                                                            | 期待                                                                                             | 関連     |
+| ---- | ------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- |
+| T-47 | 正常系       | `apperror.New(code, message)` を JSON シリアライズ                              | `{"code":"...","message":"...","request_id":"..."}` (details なし)                               | F-7, Q5  |
+| T-48 | 正常系       | `apperror.New(...).WithDetails(map[string]any{"field":"value"})` をシリアライズ | `details` フィールドに object 形式で含まれる                                                     | F-7      |
+| T-49 | セキュリティ | `details` にシークレット (例: `password`) を入れた場合                          | logger redact 経由で `[REDACTED]` 置換 (連携)                                                    | F-13     |
+| T-50 | 正常系       | `details` 型制約 (object / array のみ)                                          | string / number / bool を直接 `details` にすると compile error または runtime バリデーション失敗 | F-7      |
+| T-51 | 正常系       | error chain の `errors.Is` / `errors.As` 互換性                                 | `Unwrap()` メソッドで原因 error が取得できる                                                     | F-7      |
+| T-52 | 異常系       | request_id が context にない場合のエラーレスポンス生成                          | `request_id` フィールドは空文字、ボディは正しい JSON                                             | F-7, F-9 |
+
+## Codex レビューコマンド (各ステップで使用)
+
+各ステップ完了時に、git diff の差分のみをレビューさせる。フェーズ全体を一度にレビューしない。
+
+```bash
+# CONTEXT_DIR を変数化 (リポジトリルートからの相対パス)
+CONTEXT_DIR="docs/context"
+
+codex exec --sandbox read-only "Review the staged + unstaged Go diff in core/internal/{logger,apperror}.
+
+Context to read first:
+- ${CONTEXT_DIR}/app/architecture.md (id-core 全体像)
+- ${CONTEXT_DIR}/backend/conventions.md (Go 規約)
+- ${CONTEXT_DIR}/backend/patterns.md (httptest パターン、t.Setenv 制約)
+- docs/specs/7/index.md (本フェーズ設計書)
+- docs/specs/7/prompts/P1_01_core_logger_apperror.md (本プロンプト)
+
+Then review the current diff (use git diff). Check:
+1) TDD compliance: テストが先行コミットされているか / 各 T-N がカバーされているか
+2) Project policy compliance:
+   - UUID v4 不使用 (uuid.New / uuid.NewRandom 禁止、uuid.NewV7 のみ)
+   - log.Fatal* 不使用 (新規追加禁止)
+   - time.Local = time.UTC 不使用 (ReplaceAttr で UTC 変換すること)
+   - redact 部分一致禁止 (case-insensitive 完全一致のみ、ネスト走査必須)
+3) Go の慣用句: error wrapping (%w)、context 伝播、外部テストパッケージ命名
+4) シークレット安全性: ログ・エラーレスポンスにスタックトレースや内部パス漏洩がないか
+5) インターフェース設計: D2 の薄い独自 IF が slog.Logger を適切に隠蔽しているか
+6) 依存追加: go.mod の差分はユーザー承認済みのもののみか
+
+Report issues as CRITICAL/HIGH/MEDIUM/LOW in Japanese with file:line references."
+```
+
+## 完了条件
+
+- [ ] 作業ブランチ `feature/m0.2-impl-logger-apperror` を作成
+- [ ] `github.com/google/uuid` v1.6+ の追加についてユーザー承認を取得
+- [ ] `core/go.mod` に `github.com/google/uuid` 追加 + `go.sum` 更新
+- [ ] `core/internal/apperror/apperror.go` 実装
+- [ ] `core/internal/apperror/response.go` 実装
+- [ ] `core/internal/apperror/apperror_test.go` で T-47〜T-52 を実装、全件 pass
+- [ ] `core/internal/logger/logger.go` 実装
+- [ ] `core/internal/logger/format.go` 実装
+- [ ] `core/internal/logger/context.go` 実装
+- [ ] `core/internal/logger/redact.go` 実装
+- [ ] `core/internal/logger/fallback.go` 実装
+- [ ] `core/internal/logger/{logger,context,redact,fallback}_test.go` で T-1〜T-21 を実装、全件 pass
+- [ ] `make -C core build && make -C core test && make -C core lint` 全件 pass
+- [ ] `grep -rn "uuid\.New[^V]" core/` の出力が 0 件 (UUID v4 が混入していない)
+- [ ] 各ステップで Codex レビューを実施、CRITICAL=0 / HIGH=0 / MEDIUM<3 を確認
+- [ ] PR 作成 (`gh pr create` with `--assignee` + `--label "種別:実装" --label "対象:基盤"`)
+- [ ] `/pr-codex-review {番号}` でゲート通過
+- [ ] PR の Test plan を実機確認して `[x]` に書き換え
+- [ ] PR をマージ (Issue #12 が自動 close)
+- [ ] 親 Issue #7 の task list で #12 にチェックが付くことを確認

--- a/docs/specs/7/prompts/P2_01_core_middleware_server_main.md
+++ b/docs/specs/7/prompts/P2_01_core_middleware_server_main.md
@@ -37,6 +37,8 @@
 2. 作業ブランチ `feature/m0.2-impl-middleware-server` を `main` から切る
 3. `make -C core build && make -C core test` がベースラインで pass
 
+> **Codex レビュー対象外**: ステップ 0 はブランチ作成・前提確認のみで Go コード変更を伴わない。レビューはステップ 1 以降で実施する。
+
 ### ステップ 1: `internal/middleware/request_id.go` 実装 (F-5/F-6)
 
 1. テストを先に書く: `request_id_test.go` で T-22〜T-32 を実装 (失敗確認)
@@ -111,12 +113,14 @@
 3. **Codex レビューを実行**
 4. 指摘を対応してから次のステップへ
 
-### ステップ 7: 最終確認
+### ステップ 7: 最終確認 + 最終 Codex レビュー
 
 1. `make -C core build && make -C core test && make -C core lint` 全件 pass
 2. `grep -rn "log\.Fatal" core/` の出力が 0 件
 3. M0.1 の `/health` 外形互換 (HTTP 200 + `{"status":"ok"}` + Content-Type) が維持されていることを `httptest` で確認
-4. PR 作成 → `/pr-codex-review {番号}` でゲート通過 → ユーザー承認 → マージ
+4. PR 作成 (`gh pr create` with `--assignee` + `--label`)
+5. **`/pr-codex-review {PR 番号}` で Codex に PR 全体 (差分 + description) をレビューさせる**。これが本フェーズの最終 Codex レビュー (絶対ルール「Codex レビュー必須」を満たす全体検査)
+6. ゲート通過 (CRITICAL=0 / HIGH=0 / MEDIUM<3) → ユーザー承認 → マージ
 
 ## 実装コンテキスト
 

--- a/docs/specs/7/prompts/P2_01_core_middleware_server_main.md
+++ b/docs/specs/7/prompts/P2_01_core_middleware_server_main.md
@@ -1,0 +1,401 @@
+# P2: core/internal/middleware + server 統合 + log.Fatal 全廃
+
+- 対応 Issue: #13 (【実装】M0.2 middleware + server 統合 + log.Fatal 全廃)
+- 元要求: #7
+- 親設計書: `docs/specs/7/index.md`
+- 先行プロンプト: `docs/specs/7/prompts/P1_01_core_logger_apperror.md`
+- マイルストーン: M0.2 (Phase 0: スパイク)
+
+## 絶対ルール
+
+- **コードベース探索禁止**: Grep, Glob, Read による既存コードの探索的な読み取りを行わない
+- **Explore エージェント起動禁止**: サブエージェントによるコードベース調査を行わない
+- 実装に必要な情報は全て、以下の context ファイルとこのプロンプト内に記載済み
+- context に記載がなく実装判断できない場合は、探索ではなく**ユーザーに質問**すること
+- 変更対象ファイルの直接の Read / Edit のみ許可 (探索目的の Read は禁止)
+- **Codex レビューをスキップしない**: 各作業ステップに Codex レビューが含まれている。レビューを受けずに次のステップに進むことは禁止
+- **完了条件のタスク化**: 作業開始前に「完了条件」セクションの各項目を TaskCreate で登録し、各ステップ完了時に TaskUpdate で状態を更新すること。タスク化せずに作業を開始することは禁止
+
+### プロジェクト固有の禁止事項 (恒久ルール)
+
+- **UUID v4 禁止**: `uuid.NewV7()` のみ使用
+- **`log.Fatal*` 禁止 + 全廃**: 本 Issue の主目的。`core/cmd/core/main.go` の既存 `log.Fatalf` 2 箇所を構造化ロガー (`logger.Error` + `os.Exit(1)`) に置換する。完了条件で `grep -rn "log\.Fatal" core/` 0 件
+- **`time.Local = time.UTC` 禁止**
+- **redact 部分一致禁止**
+- **Domain 層ログ禁止**: middleware と handler のみがロガーを呼ぶ
+
+### コミット時の禁止事項
+
+- コミットメッセージに `Co-Authored-By:` trailer を入れない
+- main ブランチへ直接 push しない (feature ブランチ + PR + Codex レビュー必須)
+
+## 作業ステップ (この順序で実行すること)
+
+### ステップ 0: 前提セットアップ
+
+1. Issue #12 (P1) のマージ済みを確認 (`core/internal/{logger,apperror}/` が存在し pass する)
+2. 作業ブランチ `feature/m0.2-impl-middleware-server` を `main` から切る
+3. `make -C core build && make -C core test` がベースラインで pass
+
+### ステップ 1: `internal/middleware/request_id.go` 実装 (F-5/F-6)
+
+1. テストを先に書く: `request_id_test.go` で T-22〜T-32 を実装 (失敗確認)
+2. 実装: クライアント `X-Request-Id` の妥当性検証 (本プロンプトの「設計仕様」参照)、不正値は破棄して **UUID v7** で再生成、`context.Context` に格納、レスポンスヘッダ `X-Request-Id` を **next 呼び出し前**に先行設定 (handler が WriteHeader を呼ぶと以降のヘッダ変更が無視されるため)
+3. 不正だった元値はサニタイズ (制御文字を Unicode エスケープ、長さ 128 オクテットで切詰め) のうえ、ログにのみ別フィールド `client_request_id` として残す
+4. `make -C core lint test` が pass
+5. **Codex レビューを実行**
+6. 指摘を対応してから次のステップへ
+
+### ステップ 2: `internal/middleware/access_log.go` 実装 (F-3/F-11/D3)
+
+1. テストを先に書く: `access_log_test.go` で T-40〜T-46 を実装 (失敗確認)
+2. 実装: `defer` でリクエスト終了時に 1 行 INFO/WARN/ERROR ログを出力 (D3: 終了時のみ 1 行)。フィールド: `time` (RFC3339Nano UTC) / `level` / `msg=access` / `request_id` / `method` / `path` / `status` / `duration_ms`。レベル自動判定: 5xx=ERROR / 4xx=WARN / それ以外=INFO (F-11 / Q7)
+3. status 取得のため `http.ResponseWriter` をラップする (例: 内部 `responseWriter` 構造体で `WriteHeader` の status を捕捉)
+4. クエリ文字列に redact 対象キーが含まれる場合 (例: `?code=secret`)、ログ出力時に `[REDACTED]` 化する (T-45)
+5. `make -C core lint test` が pass
+6. **Codex レビューを実行**
+7. 指摘を対応してから次のステップへ
+
+### ステップ 3: `internal/middleware/recover.go` 実装 (F-9/F-10)
+
+1. テストを先に書く: `recover_test.go` で T-33〜T-39 を実装 (失敗確認)
+2. 実装: `defer recover()` で panic 捕捉 → 内部に level=ERROR で構造化ログを出す (`request_id` / `error` 値 / `stack_trace` フィールドに `runtime.Stack(...)` の結果)。スタックトレースは内部ログのみ、HTTP レスポンスには絶対に載せない (F-10)
+3. クライアントには HTTP 500 + `Content-Type: application/json; charset=utf-8` + F-7 基本形 JSON で固定メッセージ + `request_id` を返す: `apperror.WriteJSON(w, 500, apperror.New("INTERNAL_ERROR", "内部エラーが発生しました"), requestID)`
+4. panic value が `error` 型なら `error` フィールドに wrap、それ以外は `fmt.Sprintf("%v", v)` で文字列化
+5. `make -C core lint test` が pass
+6. **Codex レビューを実行**
+7. 指摘を対応してから次のステップへ
+
+### ステップ 4: `internal/server/server.go` の middleware チェーン組込
+
+1. テストを先に書く: `server_test.go` を更新し、middleware チェーンが組み込まれていることを統合的に検証 (T-53 が含まれる想定)
+2. 実装: D1 順序 `request_id` → `access_log` → `recover` → `handler` で wrap する。コード例:
+
+   ```go
+   handler := http.NewServeMux()
+   handler.HandleFunc("GET /health", health.Handler)
+
+   // 内側から外側へ wrap (実行は外側から)
+   var wrapped http.Handler = handler
+   wrapped = middleware.Recover(logger, wrapped)
+   wrapped = middleware.AccessLog(logger, wrapped)
+   wrapped = middleware.RequestID(wrapped)
+
+   srv := &http.Server{
+       Addr:              fmt.Sprintf(":%d", cfg.Port),
+       Handler:           wrapped,
+       ReadHeaderTimeout: readHeaderTimeout,
+   }
+   ```
+
+3. `internal/health/health.go` の `_ = json.NewEncoder(...)` の暫定コメントを解消 (write エラー時は logger に記録するか、`apperror` で処理。ただし `/health` のように handler がエラーを起こしにくい場所では受動的にログだけ残す方針で十分)
+4. `make -C core lint test` が pass
+5. **Codex レビューを実行**
+6. 指摘を対応してから次のステップへ
+
+### ステップ 5: `cmd/core/main.go` の `log.Fatal` 全廃
+
+1. テストを先に書く: `main_test.go` を新規作成し T-63〜T-65 を実装 (失敗確認)。直接 `main()` をテストするのは難しいため、`config.Load` がエラー返却時に呼ばれる「終了処理関数」を分離するなどの設計で test 可能化する
+2. 実装: 標準 `log` パッケージの利用を完全に排除。代わりに `logger.Default()` で構造化ロガーを初期化し、起動時に `event_id` (UUID v7) + `port` 付きの INFO ログを出す (msg は日本語、例: `"core サーバーを起動します"`)
+3. エラー時は `logger.Error(ctx, "設定の読み込みに失敗しました", err)` + `os.Exit(1)` で異常終了 (`log.Fatalf` を使わない)
+4. `grep -rn "log\.Fatal" core/` の出力が **0 件** であることを確認
+5. `grep -rn "\"log\"" core/` の出力が main.go から消えていることを確認 (`internal/logger` のみが log/slog を使う)
+6. `make -C core lint test` が pass
+7. **Codex レビューを実行**
+8. 指摘を対応してから次のステップへ
+
+### ステップ 6: 統合テスト (T-53〜T-57)
+
+1. テストを実装: `server_test.go` (または新規 `integration_test.go`) で middleware チェーン全体を組み立てた状態で `/health` を叩き、レスポンスヘッダ `X-Request-Id` 付与 / アクセスログ 1 行出力 / panic 経路で 500 + 固定メッセージ / 不正 `X-Request-Id` のサニタイズを検証
+2. `make -C core lint test` 全件 pass
+3. **Codex レビューを実行**
+4. 指摘を対応してから次のステップへ
+
+### ステップ 7: 最終確認
+
+1. `make -C core build && make -C core test && make -C core lint` 全件 pass
+2. `grep -rn "log\.Fatal" core/` の出力が 0 件
+3. M0.1 の `/health` 外形互換 (HTTP 200 + `{"status":"ok"}` + Content-Type) が維持されていることを `httptest` で確認
+4. PR 作成 → `/pr-codex-review {番号}` でゲート通過 → ユーザー承認 → マージ
+
+## 実装コンテキスト
+
+```
+CONTEXT_DIR="docs/context"
+```
+
+実装時に参照する context ファイル:
+
+- `${CONTEXT_DIR}/app/architecture.md`
+- `${CONTEXT_DIR}/backend/conventions.md` (Makefile 規約、環境変数、ロギング欄)
+- `${CONTEXT_DIR}/backend/patterns.md` (httptest パターン、ServeMux パターン、`t.Setenv` 制約)
+
+設計書: `docs/specs/7/index.md`
+
+先行実装: `core/internal/logger/` および `core/internal/apperror/` (P1 = #12 で完成済み)
+
+適用範囲:
+
+- `core/internal/middleware/` (新規)
+- `core/internal/server/server.go` (既存修正)
+- `core/cmd/core/main.go` (既存修正、`log.Fatal` 全廃)
+- `core/internal/health/health.go` (既存修正、暫定コメント解消)
+
+## 前提条件
+
+- **Issue #12 (P1) がマージ済み**: `core/internal/{logger,apperror}/` が完成し、`make test` が pass している状態
+- M0.1 (Issue #1, #2) 完了済み
+- 本 Issue (#13) 完了後に Issue #14 (P3: 契約テスト + context 更新 + Makefile + README) に着手可能になる
+
+## 不明点ハンドリング
+
+- 矛盾・欠落・未定義がある場合は作業を止める
+- 推測で実装を進めない
+- 質問時は: 止まっている作業単位 / 判断が必要な論点 / 選択肢を整理
+- 特に以下が判明した時点で**即停止してユーザーに質問**する:
+  - middleware の `http.ResponseWriter` ラップ方式で迷う (status 取得や hijacker 対応の必要性)
+  - panic 時のスタックトレース取得方式 (`runtime.Stack` のサイズ制限等)
+  - `cmd/core/main.go` の `os.Exit(1)` を直接呼ぶか、テスト可能な分離設計を取るか
+  - `/health` の暫定コメント解消の処理方針 (受動的ログ記録 vs apperror 処理)
+
+## タスク境界
+
+### 本プロンプトで実装する範囲
+
+- `core/internal/middleware/request_id.go` (+ `_test.go`)
+- `core/internal/middleware/access_log.go` (+ `_test.go`)
+- `core/internal/middleware/recover.go` (+ `_test.go`)
+- `core/internal/server/server.go` (修正: middleware チェーン組込、D1 順序)
+- `core/internal/server/server_test.go` (修正: 統合テスト追加 T-53〜T-57)
+- `core/cmd/core/main.go` (修正: `log.Fatal` 全廃、構造化ロガー初期化、起動 INFO ログ + `event_id`)
+- `core/cmd/core/main_test.go` (新規 / 修正: T-63〜T-65)
+- `core/internal/health/health.go` (修正: 暫定コメント解消)
+- 上記のテストケース T-22〜T-46 (middleware) + T-53〜T-57 (統合) + T-63〜T-65 (main) = **計 33 ケース**
+
+### 本プロンプトでは実装しない範囲
+
+- F-16 ログスキーマ契約テスト → P3 (Issue #14)
+- `docs/context/` 4 ファイルの更新 → P3
+- `core/Makefile` の lint で `grep -rn "log\.Fatal"` 検査追加 → P3
+- `core/README.md` の規約入口段落追加 → P3
+
+## 設計仕様
+
+### 関連要件 (F-N) の引用
+
+| ID   | 内容                                                                                                                                                                                                                                                                            |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F-3  | HTTP 経路で発生する全ログレコードに `request_id` を必須付与。フィールド: `time` / `level` / `msg` / `request_id` / `method` / `path` / `status` / `duration_ms` (アクセスログ系)                                                                                                |
+| F-5  | HTTP middleware で `request_id` を生成 (UUID v7) し `context.Context` に格納、レスポンスヘッダ `X-Request-Id` を必ず返す (4xx / 5xx / panic 時を含む)                                                                                                                           |
+| F-6  | クライアント提供 `X-Request-Id` の妥当性基準: (a) 長さ ≤ 128 オクテット (b) 文字種 ASCII 印字可能 (`0x21`–`0x7E`、制御文字・改行・空白・タブ含まない) (c) 上記を満たす場合のみ採用、満たさない場合は破棄して新規生成。元値はサニタイズしてログに `client_request_id` として残す |
+| F-9  | エラーハンドラ middleware が `panic` / 既知ドメインエラー / 未捕捉 error の 3 系統を全て規約 JSON で返す                                                                                                                                                                        |
+| F-10 | panic 発生時はクライアントへ固定メッセージ + `request_id` のみ返す。スタックトレース・内部ファイルパス・実装詳細を HTTP レスポンスへ絶対に含めない。スタックトレースは内部の構造化ログ (level=ERROR) にのみ記録                                                                 |
+| F-11 | 各種失敗ケース (panic / 4xx / 5xx) で、規約に沿った構造化ログが残る。最低ルール: 5xx および panic は `level=ERROR`、4xx は `level=WARN` 以下                                                                                                                                    |
+| F-12 | M0.1 由来の `log.Fatal*` を `core/` 配下から完全に排除する。完了条件は `grep -rn "log\.Fatal" core/` 出力が 0 件                                                                                                                                                                |
+| F-14 | Domain 層でロガーを直接呼ばない。ログ出力は middleware / handler / infrastructure 層が担当し、`context.Context` から `request_id` (または `event_id`) を取得して付与                                                                                                            |
+
+### 関連論点 (Q-N / D-N) の決定値
+
+| ID  | 決定                                                                                                                                                                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q3  | UUID v7 (v4 禁止)                                                                                                                                                   |
+| Q6  | OIDC エラーレスポンスでの `request_id` 露出方法: ヘッダ `X-Request-Id` のみ (RFC 6749 / 6750 完全準拠)。本 Issue では OIDC 実装はないが、ヘッダ常時付与の原則を守る |
+| Q7  | ログレベル: DEBUG (開発・本番無効) / INFO (業務イベント) / WARN (4xx) / ERROR (5xx・panic)                                                                          |
+| D1  | middleware 構成順序: **`request_id` (最外側) → `access_log` → `recover` → `handler`**                                                                               |
+| D3  | アクセスログ出力タイミング: 終了時のみ 1 行                                                                                                                         |
+
+### D1 順序の根拠 (重要)
+
+- `request_id` を最外側に置くことで panic 時を含む全ログレコードに `request_id` が付く
+- `recover` を `access_log` の**内側**に置くことで、handler の panic は `recover` が捕捉して 500 応答に変換されてから `access_log` の `defer` に戻る。これにより `access_log` は最終 status (500) と level (ERROR) を正しく観測できる
+- 逆順 (`access_log` → `recover` → `handler`) では `access_log.defer` が panic unwind 中に走るため `status=0` / level 誤判定になる
+
+### `X-Request-Id` レスポンスヘッダの**先行設定**ルール
+
+`request_id` middleware は `next.ServeHTTP` を呼ぶ**前**に `w.Header().Set("X-Request-Id", id)` を実行する。理由: handler が `WriteHeader` を呼んだ以降の `w.Header().Set(...)` は HTTP レスポンスに反映されない (Go の `net/http` 仕様)。
+
+```go
+func RequestID(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        id := getOrGenerate(r.Header.Get("X-Request-Id"))
+        ctx := logger.WithRequestID(r.Context(), id)
+        w.Header().Set("X-Request-Id", id) // ★ next 呼び出し前
+        next.ServeHTTP(w, r.WithContext(ctx))
+    })
+}
+```
+
+### 各 middleware の関数シグネチャ案
+
+```go
+// internal/middleware/request_id.go
+func RequestID(next http.Handler) http.Handler
+
+// internal/middleware/access_log.go
+func AccessLog(l *logger.Logger, next http.Handler) http.Handler
+
+// internal/middleware/recover.go
+func Recover(l *logger.Logger, next http.Handler) http.Handler
+```
+
+### `cmd/core/main.go` の置換イメージ
+
+```go
+package main
+
+import (
+    "context"
+    "log/slog"
+    "os"
+
+    "github.com/google/uuid"
+    "github.com/mktkhr/id-core/core/internal/config"
+    "github.com/mktkhr/id-core/core/internal/logger"
+    "github.com/mktkhr/id-core/core/internal/server"
+)
+
+func main() {
+    if err := run(); err != nil {
+        // run() 内で既にログは出ている。ここは終了処理のみ
+        os.Exit(1)
+    }
+}
+
+func run() error {
+    l, err := logger.Default()
+    if err != nil {
+        // 起動時のロガー初期化失敗は標準エラーに最終フォールバック
+        slog.Default().Error("ロガー初期化に失敗しました", "error", err)
+        return err
+    }
+
+    eventID, _ := uuid.NewV7()
+    ctx := logger.WithEventID(context.Background(), eventID.String())
+
+    cfg, err := config.Load()
+    if err != nil {
+        l.Error(ctx, "設定の読み込みに失敗しました", err)
+        return err
+    }
+
+    srv := server.New(cfg, l) // server.New が logger を受け取るシグネチャに変更
+
+    l.Info(ctx, "core サーバーを起動します", slog.String("addr", srv.Addr))
+    if err := srv.ListenAndServe(); err != nil {
+        l.Error(ctx, "サーバーの実行に失敗しました", err)
+        return err
+    }
+    return nil
+}
+```
+
+## テスト観点
+
+### `internal/middleware/request_id.go` のテスト (T-22〜T-32)
+
+| #    | カテゴリ     | 観点                                                              | 期待                                                                        | 関連     |
+| ---- | ------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------------- | -------- |
+| T-22 | 正常系       | `X-Request-Id` ヘッダなし                                         | 新規 UUID v7 生成、context 注入、レスポンスヘッダに同値設定                 | F-5, Q3  |
+| T-23 | 正常系       | クライアント `X-Request-Id: abc123-XYZ` (妥当)                    | 受け取った値をそのまま採用、context / レスポンスヘッダに同値                | F-5, F-6 |
+| T-24 | 境界値       | クライアント `X-Request-Id` が 128 オクテット ちょうど            | 採用される                                                                  | F-6      |
+| T-25 | 境界値       | クライアント `X-Request-Id` が 129 オクテット                     | 破棄、新規生成、ログに `client_request_id` (サニタイズ済) として残る        | F-6      |
+| T-26 | 異常系       | クライアント `X-Request-Id` に改行 (`\n` / `\r`) を含む           | 破棄、新規生成、`client_request_id` に制御文字を Unicode エスケープして記録 | F-6, F-1 |
+| T-27 | 異常系       | クライアント `X-Request-Id` に空白 (`0x20`) を含む                | 破棄、新規生成                                                              | F-6      |
+| T-28 | 異常系       | クライアント `X-Request-Id` にタブ (`0x09`) を含む                | 破棄、新規生成                                                              | F-6      |
+| T-29 | 異常系       | クライアント `X-Request-Id` に DEL 文字 (`0x7F`) を含む           | 破棄、新規生成 (`0x21`–`0x7E` 範囲外)                                       | F-6      |
+| T-30 | 正常系       | レスポンスヘッダ `X-Request-Id` の常時付与 (200 / 4xx / 5xx 全て) | どの status でもヘッダが必ず付く                                            | F-5      |
+| T-31 | 正常系       | UUID v7 生成方式の検証                                            | UUID 形式 (8-4-4-4-12)、バージョンビットが `7`                              | Q3       |
+| T-32 | セキュリティ | サニタイズ後 `client_request_id` 値の長さ                         | 128 オクテット以下に切り詰められる (DoS 防止)                               | F-6      |
+
+### `internal/middleware/recover.go` のテスト (T-33〜T-39)
+
+| #    | カテゴリ     | 観点                                            | 期待                                                                                                                             | 関連           |
+| ---- | ------------ | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| T-33 | 異常系       | handler が `panic("test")` した場合の HTTP 応答 | HTTP 500、Content-Type `application/json; charset=utf-8`、ボディは F-7 基本形 JSON (固定 `code` / 固定 `message` / `request_id`) | F-9, F-10, F-7 |
+| T-34 | セキュリティ | panic レスポンスにスタックトレースが含まれない  | body 内に `goroutine` / `runtime/panic` / 内部ファイルパスの文字列が現れない                                                     | F-10           |
+| T-35 | 異常系       | panic レスポンスに `request_id` が含まれる      | レスポンス JSON の `request_id` フィールドが context の値と一致                                                                  | F-9, F-5       |
+| T-36 | 異常系       | panic 時の内部ログ                              | level=ERROR、`msg` (日本語)、`request_id`、`error` 値、`stack_trace` フィールドにスタック情報を含む                              | F-10, F-11     |
+| T-37 | 正常系       | handler が panic しない場合                     | recover の defer は何もしない (パススルー)                                                                                       | F-9            |
+| T-38 | 異常系       | panic value が `error` 型の場合                 | error chain を `error` フィールドに記録                                                                                          | F-10           |
+| T-39 | 異常系       | panic value が string や任意の値の場合          | `fmt.Sprintf("%v", v)` で文字列化してログに記録                                                                                  | F-10           |
+
+### `internal/middleware/access_log.go` のテスト (T-40〜T-46)
+
+| #    | カテゴリ     | 観点                                                         | 期待                                                                                                                                        | 関連          |
+| ---- | ------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| T-40 | 正常系       | 200 OK の handler                                            | 終了時に 1 行 INFO ログ、フィールド: `time` / `level=INFO` / `msg=access` / `request_id` / `method` / `path` / `status=200` / `duration_ms` | F-3, F-11, D3 |
+| T-41 | 準正常系     | 4xx を返す handler                                           | level=WARN で出力                                                                                                                           | F-11, Q7      |
+| T-42 | 異常系       | 5xx を返す handler                                           | level=ERROR で出力                                                                                                                          | F-11, Q7      |
+| T-43 | 異常系       | recover が 500 を書いた場合                                  | access_log は最終 status=500 / level=ERROR を観測 (D1 順序の検証)                                                                           | D1            |
+| T-44 | 正常系       | `duration_ms` の精度                                         | float64 で記録、ms 単位                                                                                                                     | F-3           |
+| T-45 | セキュリティ | `path` のクエリ文字列に redact 対象キー (例: `?code=secret`) | `code` 値が `[REDACTED]` 化されてログに残る                                                                                                 | F-13, Q8      |
+| T-46 | 正常系       | 開始時はログを出さない (D3: 終了時のみ)                      | 開始時に出力されるログが存在しない                                                                                                          | D3            |
+
+### 統合テスト (T-53〜T-57)
+
+| #    | カテゴリ     | 観点                                                                       | 期待                                                                            | 関連          |
+| ---- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------- |
+| T-53 | 正常系       | middleware チェーン全体を組み立てて `GET /health` を叩く                   | 200 OK + JSON `{"status":"ok"}` (M0.1 互換) + ヘッダ `X-Request-Id`             | F-5, F-15     |
+| T-54 | 正常系       | 統合チェーン経由でログ buffer を取得し、access_log 行が 1 行出力されている | T-40 のフィールド構成と一致                                                     | F-3, D1, D3   |
+| T-55 | 異常系       | テスト用 panic endpoint を組み込んで叩く                                   | T-33〜T-36 の挙動を統合チェーンで再現                                           | F-9, F-10, D1 |
+| T-56 | セキュリティ | クライアント `Authorization: Bearer xxx` ヘッダ付きで叩く                  | アクセスログで `Authorization` が `[REDACTED]` 化される                         | F-13          |
+| T-57 | セキュリティ | クライアント `X-Request-Id` に改行入りで叩く                               | レスポンスヘッダに新規生成された UUID v7、ログに `client_request_id` として残る | F-6           |
+
+### `cmd/core/main.go` (T-63〜T-65)
+
+| #    | カテゴリ | 観点                                       | 期待                                                                                                 | 関連          |
+| ---- | -------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------- |
+| T-63 | 契約     | `grep -rn 'log\.Fatal' core/` 実行         | 出力が 0 件                                                                                          | F-12          |
+| T-64 | 異常系   | 設定読み込み失敗時の挙動                   | 構造化ロガーで `Error` ログ + `os.Exit(1)`、`log.Fatalf` を使用しない                                | F-12          |
+| T-65 | 正常系   | サーバー起動時の `event_id` 付き INFO ログ | `msg="core サーバーを起動します"` (日本語) / `event_id` (UUID v7 形式) / `addr` または `port` を含む | F-4, F-14, Q3 |
+
+## Codex レビューコマンド (各ステップで使用)
+
+```bash
+CONTEXT_DIR="docs/context"
+
+codex exec --sandbox read-only "Review the staged + unstaged Go diff in core/internal/{middleware,server,health} and core/cmd/core/.
+
+Context to read first:
+- ${CONTEXT_DIR}/app/architecture.md
+- ${CONTEXT_DIR}/backend/conventions.md
+- ${CONTEXT_DIR}/backend/patterns.md
+- docs/specs/7/index.md (本フェーズ設計書)
+- docs/specs/7/prompts/P2_01_core_middleware_server_main.md (本プロンプト)
+
+Then review the current diff (use git diff). Check:
+1) TDD compliance: テストが先行コミットされているか / 各 T-N がカバーされているか
+2) D1 middleware 順序: request_id (最外側) → access_log → recover → handler となっているか
+3) X-Request-Id レスポンスヘッダが next 呼び出し前に先行設定されているか (handler の WriteHeader 後の Set は無視される)
+4) panic 時に stack trace が HTTP レスポンスに混入していないか (内部ログのみ)
+5) UUID v7 不使用がないか (NewV7 のみ、NewRandom 禁止)
+6) log.Fatal 全廃: grep -rn 'log\\.Fatal' core/ が 0 件か、log.Fatal を使っていないか
+7) M0.1 の /health 外形互換 (200 OK + status:ok JSON) が維持されているか
+8) 起動時ログに event_id (UUID v7) と日本語メッセージが含まれるか
+9) シークレット安全性: redact が機能しているか (Authorization ヘッダ、code クエリ等)
+10) net/http の慣用句: ResponseWriter のラップ、context 伝播、defer の正しい使い方
+
+Report issues as CRITICAL/HIGH/MEDIUM/LOW in Japanese with file:line references."
+```
+
+## 完了条件
+
+- [ ] Issue #12 (P1) のマージ済みを確認
+- [ ] 作業ブランチ `feature/m0.2-impl-middleware-server` を作成
+- [ ] `core/internal/middleware/request_id.go` 実装 + `request_id_test.go` で T-22〜T-32 (11 ケース) pass
+- [ ] `core/internal/middleware/access_log.go` 実装 + `access_log_test.go` で T-40〜T-46 (7 ケース) pass
+- [ ] `core/internal/middleware/recover.go` 実装 + `recover_test.go` で T-33〜T-39 (7 ケース) pass
+- [ ] `core/internal/server/server.go` 修正: D1 順序で middleware チェーン組込
+- [ ] `core/internal/server/server_test.go` (または `integration_test.go`) で T-53〜T-57 (5 ケース) pass
+- [ ] `core/cmd/core/main.go` 修正: `log.Fatal` 全廃、構造化ロガー初期化、起動 INFO ログ + `event_id`
+- [ ] `core/cmd/core/main_test.go` で T-63〜T-65 (3 ケース) pass
+- [ ] `core/internal/health/health.go` の暫定コメント解消
+- [ ] `grep -rn "log\.Fatal" core/` の出力が **0 件**
+- [ ] `make -C core build && make -C core test && make -C core lint` 全件 pass
+- [ ] M0.1 の `/health` 外形互換 (HTTP 200 + `{"status":"ok"}` + Content-Type) を維持
+- [ ] 各ステップで Codex レビューを実施、CRITICAL=0 / HIGH=0 / MEDIUM<3
+- [ ] PR 作成 (`gh pr create` with `--assignee` + `--label "種別:実装" --label "対象:基盤" --label "対象:サーバー"`)
+- [ ] `/pr-codex-review {番号}` でゲート通過
+- [ ] PR の Test plan を実機確認して `[x]` に書き換え
+- [ ] PR をマージ (Issue #13 が自動 close)
+- [ ] 親 Issue #7 の task list で #13 にチェックが付くことを確認

--- a/docs/specs/7/prompts/P3_01_core_contract_context_makefile.md
+++ b/docs/specs/7/prompts/P3_01_core_contract_context_makefile.md
@@ -34,6 +34,8 @@
 2. 作業ブランチ `feature/m0.2-impl-contract-context` を `main` から切る
 3. `make -C core build && make -C core test && make -C core lint` がベースラインで pass
 
+> **Codex レビュー対象外**: ステップ 0 はブランチ作成・前提確認のみで成果物変更を伴わない。レビューはステップ 1 以降で実施する。
+
 ### ステップ 1: F-16 ログスキーマ契約テスト
 
 1. テストを先に書く: `core/internal/logger/contract_test.go` を新規作成し T-58〜T-62 を実装 (失敗確認)
@@ -75,7 +77,18 @@
 3. **Codex レビューを実行**
 4. 指摘を対応してから次のステップへ
 
-### ステップ 4: `docs/context/backend/conventions.md` 更新
+### ステップ 4-7: `docs/context/` 4 ファイル更新 (1 ステップで実施)
+
+context 4 ファイルは互いに整合性を取る必要があるため、**1 つのコミット単位**として実施し、末尾でまとめて Codex レビューを実行する。各ファイルの更新内容は以下のサブセクション (4-1 〜 4-4) で個別に指示する。
+
+サブステップを順次実施した後、以下を必ず実行する:
+
+1. `make -C core lint test` が pass (context 更新は core/ には影響しないが、既存テストを壊していないか確認)
+2. `npx prettier --check docs/context/backend/*.md docs/context/testing/backend.md` で整形確認 (失敗時は `--write` で整形)
+3. **Codex レビューを実行** (コマンドは末尾、context 4 ファイルの整合性検証を含める)
+4. 指摘を対応してから次のステップへ
+
+#### サブステップ 4-1: `docs/context/backend/conventions.md` 更新
 
 1. 「ロギング・テレメトリ」節の M0.1 暫定記述を**詳細化**:
    - ロガー実装: `log/slog` (Go 標準)
@@ -99,7 +112,7 @@
    - `context.Context` 経由の `request_id` / `event_id` 伝播 (Domain 層は context から取得のみ)
 4. 「環境変数」節 (registry.md と整合) に `CORE_LOG_FORMAT` を追加
 
-### ステップ 5: `docs/context/backend/patterns.md` 更新
+#### サブステップ 4-2: `docs/context/backend/patterns.md` 更新
 
 1. 「middleware チェーンパターン」節を**新設**: D1 順序の図とコード例 (`http.HandlerFunc` を wrap する実装サンプル)
 2. 「context への ID 付与パターン」節を**新設**: `WithRequestID` / `RequestIDFrom` / `WithEventID` / `EventIDFrom` のコード例。Domain 層は context から取り出すのみ
@@ -107,7 +120,7 @@
 4. 「エラーハンドリング」節を**置換**: M0.1 暫定の `fmt.Errorf` + `%w` ラップ記述を、`apperror.New(code, message)` / `WithDetails(...)` / `Wrap(cause)` パターンに置換
 5. 「ログ出力失敗時のフォールバック」節を**新設**: stderr フォールバック + atomic drop counter のコード例
 
-### ステップ 6: `docs/context/backend/registry.md` 更新
+#### サブステップ 4-3: `docs/context/backend/registry.md` 更新
 
 1. 「パッケージマッピング」表に以下を追加:
    - `core/internal/logger` (構造化ロガー、依存: `log/slog`, `github.com/google/uuid`)
@@ -116,7 +129,7 @@
 2. 「環境変数一覧」表に `CORE_LOG_FORMAT` を追加 (既定値 `json`、値は `json` または `text`、必須=任意)
 3. 「エラーコード一覧」節を新設し、最低限 `INTERNAL_ERROR` (panic 時の固定 code、F-9 / F-10) を記載。他のコードは M1.x 以降で OIDC 標準コードと統合
 
-### ステップ 7: `docs/context/testing/backend.md` 更新 (TBD → 最低限の埋め込み)
+#### サブステップ 4-4: `docs/context/testing/backend.md` 更新 (TBD → 最低限の埋め込み)
 
 1. 「Go (id-core) のテスト」節を埋める:
    - 標準パターン: `httptest.NewRequest` + `mux.ServeHTTP` (M0.1 から踏襲)
@@ -127,12 +140,14 @@
    - `grep -rn "log\.Fatal" core/` ガード (Makefile の lint で実行)
 2. 「ログスキーマ契約テスト」節を新設: F-16 のフィールド存在 + 型検証パターン。HTTP 系・非 HTTP 系の 2 系統に分割。フィールド追加は許容、削除・型変更はテスト失敗の方針
 
-### ステップ 8: 全体テスト + ベースライン確認
+### ステップ 5: 全体テスト + ベースライン確認 + 最終 Codex レビュー
 
 1. `make -C core build && make -C core test && make -C core lint` 全件 pass
 2. `grep -rn "log\.Fatal" core/` の出力が 0 件 (P2 で達成済み、本フェーズで Makefile lint がそれを保証)
 3. CI 全 green
-4. PR 作成 → `/pr-codex-review {番号}` でゲート通過 → ユーザー承認 → マージ
+4. PR 作成 (`gh pr create` with `--assignee` + `--label`)
+5. **`/pr-codex-review {PR 番号}` で Codex に PR 全体 (差分 + description) をレビューさせる**。これが本フェーズの最終 Codex レビュー (絶対ルール「Codex レビュー必須」を満たす全体検査)
+6. ゲート通過 (CRITICAL=0 / HIGH=0 / MEDIUM<3) → ユーザー承認 → マージ
 
 ## 実装コンテキスト
 

--- a/docs/specs/7/prompts/P3_01_core_contract_context_makefile.md
+++ b/docs/specs/7/prompts/P3_01_core_contract_context_makefile.md
@@ -1,0 +1,358 @@
+# P3: ログスキーマ契約テスト + context / README / Makefile 更新
+
+- 対応 Issue: #14 (【実装】M0.2 ログスキーマ契約テスト + context / README / Makefile 更新)
+- 元要求: #7
+- 親設計書: `docs/specs/7/index.md`
+- 先行プロンプト: `P1_01_core_logger_apperror.md` / `P2_01_core_middleware_server_main.md`
+- マイルストーン: M0.2 (Phase 0: スパイク)
+
+## 絶対ルール
+
+- **コードベース探索禁止**: Grep, Glob, Read による既存コードの探索的な読み取りを行わない
+- **Explore エージェント起動禁止**: サブエージェントによるコードベース調査を行わない
+- 実装に必要な情報は全て、以下の context ファイルとこのプロンプト内に記載済み
+- context に記載がなく実装判断できない場合は、探索ではなく**ユーザーに質問**すること
+- 変更対象ファイルの直接の Read / Edit のみ許可 (探索目的の Read は禁止)
+- **Codex レビューをスキップしない**: 各作業ステップに Codex レビューが含まれている。レビューを受けずに次のステップに進むことは禁止
+- **完了条件のタスク化**: 作業開始前に「完了条件」セクションの各項目を TaskCreate で登録し、各ステップ完了時に TaskUpdate で状態を更新すること。タスク化せずに作業を開始することは禁止
+
+### プロジェクト固有の禁止事項 (恒久ルール)
+
+- **UUID v4 禁止** / **`log.Fatal*` 禁止** / **`time.Local = time.UTC` 禁止** / **redact 部分一致禁止** / **Domain 層ログ禁止** (詳細は P1 / P2 参照)
+- **context 4 ファイルへの記述で「アーカイブ」「特定リポジトリ名」「社内固有事情」を書かない**: 公開リポジトリ前提のテンプレート扱い
+
+### コミット時の禁止事項
+
+- コミットメッセージに `Co-Authored-By:` trailer を入れない
+- main ブランチへ直接 push しない (feature ブランチ + PR + Codex レビュー必須)
+
+## 作業ステップ (この順序で実行すること)
+
+### ステップ 0: 前提セットアップ
+
+1. Issue #12 (P1) と Issue #13 (P2) が両方マージ済みを確認 (`core/internal/{logger,apperror,middleware}/` が完成し、`server.go` / `main.go` / `health.go` が更新済み)
+2. 作業ブランチ `feature/m0.2-impl-contract-context` を `main` から切る
+3. `make -C core build && make -C core test && make -C core lint` がベースラインで pass
+
+### ステップ 1: F-16 ログスキーマ契約テスト
+
+1. テストを先に書く: `core/internal/logger/contract_test.go` を新規作成し T-58〜T-62 を実装 (失敗確認)
+2. 実装方針: テスト用 `bytes.Buffer` を writer に渡してロガーを初期化、HTTP 系と非 HTTP 系それぞれで 1 行ログ出力 → JSON decode → 必須フィールドの存在 + 型を `t.Fatalf` で検証
+3. `make -C core lint test` 全件 pass
+4. **Codex レビューを実行**
+5. 指摘を対応してから次のステップへ
+
+### ステップ 2: `core/Makefile` の lint で `log.Fatal` 検査追加
+
+1. テストを先に書く: shell ベースの試験 (CI 上の grep 結果) で簡単に検証する。Makefile の `lint` target を実行した際に、`core/` 配下に `log.Fatal*` を**新規追加**したファイルがあれば lint failure になることを確認
+2. 実装方針: `lint` target に以下を追加 (実装者は具体的なシェル構文を整える)
+
+   ```makefile
+   .PHONY: lint
+   lint:
+   	@echo "==> go vet"
+   	@go vet ./...
+   	@echo "==> log.Fatal check"
+   	@if grep -rn 'log\.Fatal' . --include='*.go' | grep -v '_test\.go'; then \
+   		echo "ERROR: log.Fatal* is forbidden in core/. Use logger.Error + os.Exit(1) instead."; \
+   		exit 1; \
+   	fi
+   ```
+
+3. `make -C core lint` が pass することを確認
+4. 試験的に `core/cmd/core/main.go` に `log.Fatalf("test")` を一時追加して `make -C core lint` が **失敗**することを確認 (確認後に元に戻す)
+5. **Codex レビューを実行**
+6. 指摘を対応してから次のステップへ
+
+### ステップ 3: `core/README.md` にログ・エラー規約の入口段落を追加
+
+1. 既存の `core/README.md` に以下のような段落を追記 (既存の構造を尊重しながら)
+2. 内容:
+   - ログ・エラー規約の概要 (1〜2 段落)
+   - `CORE_LOG_FORMAT` 環境変数の説明 (デフォルト `json`、開発時は `text`)
+   - `docs/context/backend/conventions.md` のロギング・テレメトリ節とエラーハンドリング節へのリンク
+   - panic 時のレスポンス形式 (`{ code: "INTERNAL_ERROR", message: "...", request_id: "..." }`) の言及
+3. **Codex レビューを実行**
+4. 指摘を対応してから次のステップへ
+
+### ステップ 4: `docs/context/backend/conventions.md` 更新
+
+1. 「ロギング・テレメトリ」節の M0.1 暫定記述を**詳細化**:
+   - ロガー実装: `log/slog` (Go 標準)
+   - フォーマット切替: `CORE_LOG_FORMAT=json|text` (デフォルト `json`)
+   - 一意 ID 生成: UUID v7 (`github.com/google/uuid` v1.6+ の `uuid.NewV7()`、v4 は使用禁止)
+   - `time` フィールド: RFC3339Nano UTC、`Z` suffix 強制 (`slog` の `ReplaceAttr` で UTC 変換、`time.Local = time.UTC` は禁止)
+   - ログレベル使い分け表 (DEBUG=本番無効 / INFO=業務イベント / WARN=4xx / ERROR=5xx・panic)
+   - HTTP 経路 / 非 HTTP 経路の必須フィールド一覧
+   - ログ出力失敗時の挙動 (stderr フォールバック + atomic drop counter、リクエスト処理は継続)
+   - ログメッセージ言語: 日本語
+2. 「エラーハンドリング」節を**新設**:
+   - `internal/apperror/` パッケージ
+   - F-7 基本形 `{ code, message, details?, request_id }` の JSON 形式
+   - `code` 命名規則: `SCREAMING_SNAKE_CASE`
+   - `details` の型制約: object / array のみ、シークレット禁止 (redact 連携)
+   - redact 対象キー一覧 (Q8 完全リスト 16 キー + 6 ヘッダ、case-insensitive 完全一致、ネスト・配列再帰走査、`[REDACTED]` 固定値)
+   - OIDC エンドポイント (M1.x 以降) の RFC 6749 / 6750 準拠方針
+3. 「middleware 構成」節を**新設**:
+   - D1 順序: `request_id` → `access_log` → `recover` → `handler`
+   - 各 middleware の責務
+   - `context.Context` 経由の `request_id` / `event_id` 伝播 (Domain 層は context から取得のみ)
+4. 「環境変数」節 (registry.md と整合) に `CORE_LOG_FORMAT` を追加
+
+### ステップ 5: `docs/context/backend/patterns.md` 更新
+
+1. 「middleware チェーンパターン」節を**新設**: D1 順序の図とコード例 (`http.HandlerFunc` を wrap する実装サンプル)
+2. 「context への ID 付与パターン」節を**新設**: `WithRequestID` / `RequestIDFrom` / `WithEventID` / `EventIDFrom` のコード例。Domain 層は context から取り出すのみ
+3. 「redact パターン」節を**新設**: `internal/logger/redact.go` の deny-list 実装の最小サンプル (case-insensitive ヘッダ照合 / JSON 再帰走査 / `[REDACTED]` 固定置換)
+4. 「エラーハンドリング」節を**置換**: M0.1 暫定の `fmt.Errorf` + `%w` ラップ記述を、`apperror.New(code, message)` / `WithDetails(...)` / `Wrap(cause)` パターンに置換
+5. 「ログ出力失敗時のフォールバック」節を**新設**: stderr フォールバック + atomic drop counter のコード例
+
+### ステップ 6: `docs/context/backend/registry.md` 更新
+
+1. 「パッケージマッピング」表に以下を追加:
+   - `core/internal/logger` (構造化ロガー、依存: `log/slog`, `github.com/google/uuid`)
+   - `core/internal/apperror` (エラー型 + JSON シリアライザ)
+   - `core/internal/middleware` (request_id / access_log / recover、依存: `internal/logger`, `internal/apperror`)
+2. 「環境変数一覧」表に `CORE_LOG_FORMAT` を追加 (既定値 `json`、値は `json` または `text`、必須=任意)
+3. 「エラーコード一覧」節を新設し、最低限 `INTERNAL_ERROR` (panic 時の固定 code、F-9 / F-10) を記載。他のコードは M1.x 以降で OIDC 標準コードと統合
+
+### ステップ 7: `docs/context/testing/backend.md` 更新 (TBD → 最低限の埋め込み)
+
+1. 「Go (id-core) のテスト」節を埋める:
+   - 標準パターン: `httptest.NewRequest` + `mux.ServeHTTP` (M0.1 から踏襲)
+   - 外部テストパッケージ命名 (`<pkg>_test`)
+   - `t.Setenv` と `t.Parallel` の併用不可 (Go 仕様)
+   - テーブル駆動テスト (redact deny-list で活用)
+   - ログ buffer での検証パターン (`bytes.Buffer` を `slog` ハンドラに渡し、JSON decode で検証)
+   - `grep -rn "log\.Fatal" core/` ガード (Makefile の lint で実行)
+2. 「ログスキーマ契約テスト」節を新設: F-16 のフィールド存在 + 型検証パターン。HTTP 系・非 HTTP 系の 2 系統に分割。フィールド追加は許容、削除・型変更はテスト失敗の方針
+
+### ステップ 8: 全体テスト + ベースライン確認
+
+1. `make -C core build && make -C core test && make -C core lint` 全件 pass
+2. `grep -rn "log\.Fatal" core/` の出力が 0 件 (P2 で達成済み、本フェーズで Makefile lint がそれを保証)
+3. CI 全 green
+4. PR 作成 → `/pr-codex-review {番号}` でゲート通過 → ユーザー承認 → マージ
+
+## 実装コンテキスト
+
+```
+CONTEXT_DIR="docs/context"
+```
+
+実装時に参照する context ファイル (本フェーズで更新する側):
+
+- `${CONTEXT_DIR}/app/architecture.md`
+- `${CONTEXT_DIR}/backend/conventions.md` (本フェーズで更新)
+- `${CONTEXT_DIR}/backend/patterns.md` (本フェーズで更新)
+- `${CONTEXT_DIR}/backend/registry.md` (本フェーズで更新)
+- `${CONTEXT_DIR}/testing/backend.md` (本フェーズで更新)
+
+設計書: `docs/specs/7/index.md` (特に「既存資料からの差分」節を参照)
+
+先行実装: `core/internal/{logger,apperror,middleware}/` および `core/internal/server/`、`core/cmd/core/main.go` (P1 / P2 で完成済み)
+
+適用範囲:
+
+- `core/internal/logger/contract_test.go` (新規)
+- `docs/context/backend/{conventions,patterns,registry}.md` (既存修正)
+- `docs/context/testing/backend.md` (既存修正、TBD → 最低限埋める)
+- `core/Makefile` (既存修正、lint で grep 検査)
+- `core/README.md` (既存修正、規約入口段落)
+
+## 前提条件
+
+- **Issue #12 (P1) と Issue #13 (P2) が両方マージ済み**: `core/internal/{logger,apperror,middleware}/` が完成し、`server.go` / `main.go` / `health.go` が更新済み
+- M0.1 (Issue #1, #2) 完了済み
+- 本 Issue (#14) のマージで M0.2 マイルストーンが完了する
+
+## 不明点ハンドリング
+
+- 矛盾・欠落・未定義がある場合は作業を止める
+- 推測で実装を進めない
+- 質問時は: 止まっている作業単位 / 判断が必要な論点 / 選択肢を整理
+- 特に以下が判明した時点で**即停止してユーザーに質問**する:
+  - F-16 契約テストでフィールド存在 + 型を JSON decode 後にどこまで厳密にチェックするか
+  - Makefile の lint で `log.Fatal` 検査を実装する具体的な構文 (POSIX shell vs GNU make の互換性)
+  - context ファイルの既存記述と本プロンプトの新規記述で表現が衝突する場合の優先順位
+
+## タスク境界
+
+### 本プロンプトで実装する範囲
+
+- `core/internal/logger/contract_test.go` (新規、T-58〜T-62 の 5 ケース)
+- `docs/context/backend/conventions.md` (ロギング・テレメトリ詳細化、エラーハンドリング新設、middleware 構成新設、環境変数追記)
+- `docs/context/backend/patterns.md` (middleware チェーンパターン / context ID 付与 / redact パターン / エラーハンドリング置換 / フォールバックパターン)
+- `docs/context/backend/registry.md` (パッケージマッピング 3 件追加、環境変数 1 件追加、エラーコード一覧新設)
+- `docs/context/testing/backend.md` (Go テスト節埋め、ログスキーマ契約テスト節新設)
+- `core/Makefile` (lint で `grep -rn "log\.Fatal"` 検査追加)
+- `core/README.md` (ログ・エラー規約の入口段落追加)
+- 上記のテストケース T-58〜T-62 = **5 ケース**
+
+### 本プロンプトでは実装しない範囲
+
+- `core/internal/{logger,apperror,middleware}/` のコア実装 → P1 / P2 で完了済み
+- `core/internal/server/server.go` / `core/cmd/core/main.go` の修正 → P2 で完了済み
+
+## 設計仕様
+
+### 関連要件 (F-N) の引用
+
+| ID   | 内容                                                                                                                                                                                                                                                                                            |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F-12 | M0.1 由来の `log.Fatal*` を `core/` 配下から完全に排除する。完了条件は `grep -rn "log\.Fatal" core/` 出力が 0 件 (P2 で達成、本フェーズで Makefile lint が違反を CI で検知)                                                                                                                     |
+| F-15 | `core/` で `make build && make test && make lint` が pass する                                                                                                                                                                                                                                  |
+| F-16 | ログスキーマ契約テストが用意されている。検証対象は最低 2 系統に分割: (a) HTTP 経路系 — `time` / `level` / `msg` / `request_id` / `method` / `path` / `status` / `duration_ms` の存在と型 (最低 1 ケース)、(b) 非 HTTP 経路系 — `time` / `level` / `msg` / `event_id` の存在と型 (最低 1 ケース) |
+| F-17 | 規約書が存在する。最低必須項目: ログフィールド定義 / エラー境界 / redact 対象キーの完全一覧と適用面 / ログレベル使い分けガイド / 開発者向け運用手順                                                                                                                                             |
+
+### 関連論点 (Q-N) の決定値
+
+| ID  | 決定                                                                                                                                                                                                   |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Q10 | 規約書の格納場所: **`docs/context/backend/conventions.md` のロギング・テレメトリ節を本スコープで詳細化 + エラーハンドリング節を新設して `apperror` 規約を記載** (新規ディレクトリ作成は回避、単一 SoT) |
+
+### F-16 契約テストの実装方針 (詳細)
+
+```go
+// core/internal/logger/contract_test.go の構造例 (実装者がテーブル駆動で書く)
+
+package logger_test
+
+import (
+    "bytes"
+    "encoding/json"
+    "testing"
+
+    "github.com/mktkhr/id-core/core/internal/logger"
+)
+
+func TestContract_HTTPPathSchema(t *testing.T) {
+    // T-58: HTTP 経路ログ (msg=access) のフィールド存在 + 型
+    var buf bytes.Buffer
+    l := logger.New(logger.FormatJSON, &buf)
+    // ... access_log middleware が出すログを模した出力を作る
+    // ... json.Unmarshal で map[string]any にデコード
+    // ... 必須フィールドが存在するか + 型が一致するか検証
+}
+
+func TestContract_NonHTTPPathSchema(t *testing.T) {
+    // T-59: 非 HTTP 経路ログのフィールド存在 + 型
+    // ... event_id を持つログを出して同様に検証
+}
+
+func TestContract_FieldAdditionAllowed(t *testing.T) {
+    // T-60: 追加フィールドが含まれてもテストは失敗しない
+}
+
+func TestContract_FieldRemovalFails(t *testing.T) {
+    // T-61: 必須フィールドが欠けるとテスト失敗
+    // (実装者が「フィールド欠落の状態」を意図的に作ってテスト)
+}
+
+func TestContract_FieldTypeChangeFails(t *testing.T) {
+    // T-62: 型不一致でテスト失敗
+}
+```
+
+### `core/README.md` 追記の具体案
+
+既存 README の構造を尊重しつつ、新規節 (例: 「ログ・エラー規約」) として:
+
+```markdown
+## ログ・エラー規約
+
+`core/` のログとエラーレスポンスは構造化規約に従う:
+
+- **ログ**: `log/slog` ベースの JSON Lines (本番) / Text (開発、`CORE_LOG_FORMAT=text` で切替)
+- **request_id**: 全 HTTP リクエストに UUID v7 で発番、レスポンスヘッダ `X-Request-Id` で返却
+- **エラーレスポンス**: `internal/apperror/` パッケージの基本形 `{ code, message, details?, request_id }`
+- **panic 時**: 固定メッセージ + `request_id` のみ返し、スタックトレースは内部ログにのみ記録
+
+詳細な規約は [`docs/context/backend/conventions.md`](../docs/context/backend/conventions.md) のロギング・テレメトリ節とエラーハンドリング節を参照。
+
+### 環境変数
+
+| Key               | 既定値 | 値の例               | 説明                          |
+| ----------------- | ------ | -------------------- | ----------------------------- |
+| `CORE_PORT`       | `8080` | `1`〜`65535` の整数  | HTTP サーバーのリッスンポート |
+| `CORE_LOG_FORMAT` | `json` | `json` または `text` | ログ出力フォーマットの切替    |
+```
+
+### `core/Makefile` 追記の具体案
+
+```makefile
+.PHONY: lint
+lint:
+	@echo "==> go vet"
+	@go vet ./...
+	@echo "==> log.Fatal* check (project policy: forbidden in core/)"
+	@if grep -rn --include='*.go' --exclude='*_test.go' 'log\.Fatal' . ; then \
+		echo "ERROR: log.Fatal* is forbidden in core/. Use logger.Error + os.Exit(1) instead."; \
+		exit 1; \
+	fi
+```
+
+(注: `--include` / `--exclude` は GNU grep の機能。POSIX 互換が必要なら `find ... | xargs grep` パターンに変える)
+
+## テスト観点
+
+### F-16 ログスキーマ契約テスト (T-58〜T-62)
+
+| #    | カテゴリ | 観点                                                                 | 期待                                                                                                                                                                                  | 関連      |
+| ---- | -------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| T-58 | 契約     | HTTP 経路ログ (`msg=access`) のフィールド存在 + 型                   | 必須: `time` (string, RFC3339Nano UTC) / `level` (string) / `msg` (string) / `request_id` (string) / `method` (string) / `path` (string) / `status` (number) / `duration_ms` (number) | F-16      |
+| T-59 | 契約     | 非 HTTP 経路ログ (起動 / signal handler / job) のフィールド存在 + 型 | 必須: `time` (string) / `level` (string) / `msg` (string) / `event_id` (string)                                                                                                       | F-16, F-4 |
+| T-60 | 契約     | フィールド追加は許容 (将来の拡張)                                    | 追加フィールドが含まれてもテスト失敗しない                                                                                                                                            | F-16      |
+| T-61 | 契約     | フィールド削除は失敗 (破壊的変更検知)                                | 必須フィールドが欠けると `t.Errorf` で失敗                                                                                                                                            | F-16      |
+| T-62 | 契約     | フィールド型変更は失敗 (例: `status` が string になる等)             | 型不一致でテスト失敗                                                                                                                                                                  | F-16      |
+
+## Codex レビューコマンド (各ステップで使用)
+
+```bash
+CONTEXT_DIR="docs/context"
+
+codex exec --sandbox read-only "Review the staged + unstaged diff (Go + Makefile + Markdown).
+
+Context to read first:
+- ${CONTEXT_DIR}/app/architecture.md
+- ${CONTEXT_DIR}/backend/conventions.md
+- ${CONTEXT_DIR}/backend/patterns.md
+- ${CONTEXT_DIR}/backend/registry.md
+- ${CONTEXT_DIR}/testing/backend.md
+- docs/specs/7/index.md (本フェーズ設計書、特に「既存資料からの差分」節)
+- docs/specs/7/prompts/P3_01_core_contract_context_makefile.md (本プロンプト)
+
+Then review the current diff (use git diff). Check:
+1) F-16 contract test: HTTP 系 + 非 HTTP 系の両方をカバー、フィールド存在 + 型を厳密に検証
+2) Makefile lint で log.Fatal 検査が機能する (新規追加で lint failure する)
+3) README の規約入口段落が conventions.md と registry.md にリンクし、内容矛盾がない
+4) context 4 ファイルの整合: conventions.md (規約本文) / patterns.md (実装サンプル) / registry.md (パッケージ・環境変数・エラーコード) / testing/backend.md (テストパターン) が一貫している
+5) M0.1 の既存記述 (TBD 等) を勝手に消していないか / 必要な節だけを更新しているか
+6) アーカイブ参照や特定リポジトリ名の混入がないか (公開リポジトリ前提)
+7) 設計書 docs/specs/7/index.md の「既存資料からの差分」節の指示と齟齬がないか
+
+Report issues as CRITICAL/HIGH/MEDIUM/LOW in Japanese with file:line references."
+```
+
+## 完了条件
+
+- [ ] Issue #12 (P1) と Issue #13 (P2) のマージ済みを確認
+- [ ] 作業ブランチ `feature/m0.2-impl-contract-context` を作成
+- [ ] `core/internal/logger/contract_test.go` 実装、T-58〜T-62 全件 pass
+- [ ] `core/Makefile` の `lint` target に `grep -rn "log\.Fatal" core/` 検査を追加、既存テスト pass を維持
+- [ ] `core/Makefile` の lint が `log.Fatal` 新規追加を検知する (試験的に追加して `make -C core lint` 失敗を確認 → 戻す)
+- [ ] `core/README.md` にログ・エラー規約の入口段落を追加
+- [ ] `docs/context/backend/conventions.md` を更新 (ロギング・テレメトリ詳細化、エラーハンドリング節新設、middleware 構成節新設、環境変数追記)
+- [ ] `docs/context/backend/patterns.md` を更新 (middleware チェーン / context ID 付与 / redact / エラーハンドリング / フォールバック)
+- [ ] `docs/context/backend/registry.md` を更新 (パッケージマッピング、環境変数、エラーコード)
+- [ ] `docs/context/testing/backend.md` を最低限の内容で埋める
+- [ ] `make -C core build && make -C core test && make -C core lint` 全件 pass
+- [ ] `grep -rn "log\.Fatal" core/` の出力が 0 件 (P2 で達成済み、本フェーズで保護)
+- [ ] 各ステップで Codex レビューを実施、CRITICAL=0 / HIGH=0 / MEDIUM<3
+- [ ] PR 作成 (`gh pr create` with `--assignee` + `--label "種別:実装" --label "対象:基盤"`)
+- [ ] `/pr-codex-review {番号}` でゲート通過
+- [ ] PR の Test plan を実機確認して `[x]` に書き換え
+- [ ] PR をマージ (Issue #14 が自動 close)
+- [ ] 親 Issue #7 の task list で #14 にチェックが付くことを確認
+- [ ] **M0.2 マイルストーンを close** (全実装 Issue #12 / #13 / #14 の close 後にユーザーが実施、または提案)
+- [ ] 親要求 Issue #7 を close (M0.2 完了確認後にユーザーが実施)


### PR DESCRIPTION
## Summary

`/spec-prompts` で実装プロンプト 3 件を `docs/specs/7/prompts/` 配下に生成。各 Issue (#12 / #13 / #14) の本文にも参照リンクを追記済み。

### 生成ファイル

| ファイル | 対応 Issue | 概要 |
|---|---|---|
| `P1_01_core_logger_apperror.md` | #12 | logger + apperror パッケージ実装 (基盤) |
| `P2_01_core_middleware_server_main.md` | #13 | middleware + server 統合 + log.Fatal 全廃 |
| `P3_01_core_contract_context_makefile.md` | #14 | F-16 契約テスト + context 4 ファイル + Makefile + README |

### プロンプトの設計

- 自己完結型 (`.rulesync/rules/path-resolution.md` 準拠): プロンプトファイル + コードベースだけで実装着手可能
- テンプレート絶対ガード 10 セクションを全件含む
- T-N 網羅: P1=27 + P2=33 + P3=5 = 65 ケース
- プロジェクト固有の禁止事項 (UUID v4 / log.Fatal / time.Local / redact 部分一致 / Domain 層ログ / Co-Authored-By / 直接 push) を全プロンプトで明記

## Review

- Codex PR レビュー初回 (`.ai-out/codex-pr-16-review-...104638.md`): HIGH 3 / MEDIUM 0 / LOW 0 (Step 0 と最終ステップで Codex レビュー手順が抜けていた)
- 修正: 各プロンプトの Step 0 に「Codex レビュー対象外: 準備のみ」を明示、最終ステップに `/pr-codex-review {番号}` を番号付き手順として明示、P3 のドキュメント更新ステップ 4-7 を 1 つの「ステップ 4-7」(サブステップ化) にまとめ末尾でレビュー
- Codex PR レビュー再実行: CRITICAL 0 / HIGH 0 / MEDIUM 0 / LOW 0 → ゲート pass

## Test plan

- [x] 3 プロンプトファイルが `docs/specs/7/prompts/` 配下に生成されている
- [x] 各プロンプトに 10 必須セクションが全て含まれる (`grep -E '^## ...' docs/specs/7/prompts/P1...md | wc -l` → 10)
- [x] T-N 網羅 (P1=27 / P2=33 / P3=5、合計 65)
- [x] 各 Issue (#12 / #13 / #14) の本文にプロンプトファイルへの参照リンクが追記されている
- [x] prettier で整形済み
- [x] `/pr-codex-review` 再実行でゲート通過 (CRITICAL=0 / HIGH=0 / MEDIUM=0)

Refs #7