### PR TITLE
feat:✨ M0.2 logger + apperror パッケージ実装 (P1)

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -1,3 +1,5 @@
 module github.com/mktkhr/id-core/core
 
 go 1.26.2
+
+require github.com/google/uuid v1.6.0 // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/core/internal/apperror/apperror.go
+++ b/core/internal/apperror/apperror.go
@@ -1,0 +1,104 @@
+// Package apperror は内部 API のエラーレスポンス型と JSON シリアライズを提供する。
+//
+// 仕様 F-7: { "code": string, "message": string, "details"?: object, "request_id": string }
+package apperror
+
+import "fmt"
+
+// CodeInternalError は予期しないエラー (panic 含む) の固定 code。
+// HTTP middleware の recover からの最終受け皿として使う。
+const CodeInternalError = "INTERNAL_ERROR"
+
+// CodedError は内部 API のエラーレスポンスを表す型。
+//
+// immutable: WithDetails / Wrap は新しいインスタンスを返し、レシーバを変更しない。
+// errors.Is / errors.As は Unwrap 経由で cause を辿る。
+type CodedError struct {
+	code    string
+	message string
+	details map[string]any
+	cause   error
+}
+
+// New は CodedError を新規作成する。
+//
+// code は SCREAMING_SNAKE_CASE を推奨 (例: "INVALID_PARAMETER")。
+// message は人間可読の本文 (本スコープでは日本語)。
+func New(code, message string) *CodedError {
+	return &CodedError{code: code, message: message}
+}
+
+// WithDetails は details を付与した新しいインスタンスを返す。
+//
+// 仕様 F-7 は details を "object / array" に限定するが、本実装は top-level を
+// object (map[string]any) に統一する。配列を入れたい場合は object のキー配下に
+// ネストする (例: {"errors": [...]})。
+//
+// immutable 契約のため details は deep-copy する: 呼び出し元が後から map を変更しても
+// CodedError 内部状態には影響しない。
+func (e *CodedError) WithDetails(details map[string]any) *CodedError {
+	cp := *e
+	cp.details = cloneDetails(details)
+	return &cp
+}
+
+// Wrap は原因 error をラップして error chain を作る。
+func (e *CodedError) Wrap(cause error) *CodedError {
+	cp := *e
+	cp.cause = cause
+	return &cp
+}
+
+// Code は error code を返す。
+func (e *CodedError) Code() string { return e.code }
+
+// Message は人間可読メッセージを返す。
+func (e *CodedError) Message() string { return e.message }
+
+// Details は details オブジェクトのコピーを返す (nil 可)。
+//
+// immutable 契約のため deep-copy を返す: 取得側が変更しても CodedError 内部状態には
+// 影響しない。シリアライズ目的では Response 経由が推奨。
+func (e *CodedError) Details() map[string]any { return cloneDetails(e.details) }
+
+// Error は error インターフェースを満たす。
+//
+// 注意: クライアント返却用の文字列ではなく、サーバー内部のログ・スタックトレース用。
+// 公開エラーレスポンスには Response 経由で出力する。
+func (e *CodedError) Error() string {
+	if e.cause != nil {
+		return fmt.Sprintf("%s: %s: %v", e.code, e.message, e.cause)
+	}
+	return fmt.Sprintf("%s: %s", e.code, e.message)
+}
+
+// Unwrap は errors.Is / errors.As のために cause を返す。
+func (e *CodedError) Unwrap() error { return e.cause }
+
+// cloneDetails は map[string]any を再帰的にディープコピーする。
+// 配下に map[string]any / []any を含むケースを再帰走査する。プリミティブ値は値渡し。
+func cloneDetails(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = cloneValue(v)
+	}
+	return out
+}
+
+func cloneValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return cloneDetails(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, item := range t {
+			out[i] = cloneValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/core/internal/apperror/apperror_test.go
+++ b/core/internal/apperror/apperror_test.go
@@ -1,0 +1,211 @@
+package apperror_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/apperror"
+)
+
+// T-47: New を JSON シリアライズ。details が無いケース。
+func TestToResponse_BasicForm(t *testing.T) {
+	e := apperror.New("INVALID_PARAMETER", "不正なパラメータです")
+
+	resp := apperror.ToResponse(e, "req-1")
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got["code"] != "INVALID_PARAMETER" {
+		t.Errorf("code = %v, want INVALID_PARAMETER", got["code"])
+	}
+	if got["message"] != "不正なパラメータです" {
+		t.Errorf("message = %v", got["message"])
+	}
+	if got["request_id"] != "req-1" {
+		t.Errorf("request_id = %v, want req-1", got["request_id"])
+	}
+	if _, ok := got["details"]; ok {
+		t.Errorf("details should be omitted when nil, got %v", got["details"])
+	}
+}
+
+// T-48: WithDetails を付けて JSON シリアライズ。
+func TestToResponse_WithDetails(t *testing.T) {
+	e := apperror.New("INVALID_PARAMETER", "不正").WithDetails(map[string]any{
+		"field":  "email",
+		"reason": "format",
+	})
+
+	resp := apperror.ToResponse(e, "req-2")
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	details, ok := got["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("details should be JSON object, got %T", got["details"])
+	}
+	if details["field"] != "email" {
+		t.Errorf("details.field = %v, want email", details["field"])
+	}
+	if details["reason"] != "format" {
+		t.Errorf("details.reason = %v, want format", details["reason"])
+	}
+}
+
+// T-50: details の型制約を文書化する。
+// WithDetails は map[string]any しか受け取らないため、string / number / bool / array
+// を直接渡すと compile error になる。本テストは正の振る舞いを検証することで
+// 型シグネチャによる制約を成立させていることを文書化する。
+func TestWithDetails_TypeConstraint_AcceptsObjectOnly(t *testing.T) {
+	// object (map[string]any) は受け取れる。
+	e := apperror.New("X", "x").WithDetails(map[string]any{"k": "v"})
+	if got := e.Details()["k"]; got != "v" {
+		t.Errorf("Details()[k] = %v, want v", got)
+	}
+
+	// 配列を入れたい場合は object のキーにネストすることで仕様 F-7 (object / array) の
+	// "array" 表現を満たす設計とする。
+	e2 := apperror.New("X", "x").WithDetails(map[string]any{
+		"errors": []any{"a", "b"},
+	})
+	arr, ok := e2.Details()["errors"].([]any)
+	if !ok || len(arr) != 2 {
+		t.Errorf("nested array not preserved: %v", e2.Details())
+	}
+}
+
+// 補助テスト: immutable 契約。WithDetails / Details() で deep-copy が効いていること。
+func TestCodedError_Immutable_DeepCopy(t *testing.T) {
+	src := map[string]any{
+		"top":    "v",
+		"nested": map[string]any{"k": "n"},
+		"arr":    []any{map[string]any{"x": 1}},
+	}
+	e := apperror.New("X", "x").WithDetails(src)
+
+	// 1. 入力 src を変更しても CodedError 内部状態は不変。
+	src["top"] = "tampered"
+	src["nested"].(map[string]any)["k"] = "tampered"
+	src["arr"].([]any)[0].(map[string]any)["x"] = 999
+
+	got := e.Details()
+	if got["top"] != "v" {
+		t.Errorf("WithDetails: top mutated by external src: got %v", got["top"])
+	}
+	if got["nested"].(map[string]any)["k"] != "n" {
+		t.Errorf("WithDetails: nested map mutated: got %v", got["nested"])
+	}
+	if got["arr"].([]any)[0].(map[string]any)["x"] != 1 {
+		t.Errorf("WithDetails: array element mutated: got %v", got["arr"])
+	}
+
+	// 2. Details() 戻り値を変更しても CodedError 内部状態は不変。
+	got["top"] = "tampered2"
+	got["nested"].(map[string]any)["k"] = "tampered2"
+
+	got2 := e.Details()
+	if got2["top"] != "v" {
+		t.Errorf("Details(): top mutated by returned map: got %v", got2["top"])
+	}
+	if got2["nested"].(map[string]any)["k"] != "n" {
+		t.Errorf("Details(): nested map mutated: got %v", got2["nested"])
+	}
+}
+
+// T-51: errors.Is / errors.As 互換性 (Unwrap)。
+func TestCodedError_Unwrap(t *testing.T) {
+	root := errors.New("ルート原因")
+	wrapped := apperror.New("INTERNAL_ERROR", "内部エラー").Wrap(root)
+
+	if !errors.Is(wrapped, root) {
+		t.Errorf("errors.Is(wrapped, root) = false, want true")
+	}
+
+	var target *apperror.CodedError
+	if !errors.As(wrapped, &target) {
+		t.Fatalf("errors.As(wrapped, *CodedError) = false")
+	}
+	if target.Code() != "INTERNAL_ERROR" {
+		t.Errorf("target.Code() = %v, want INTERNAL_ERROR", target.Code())
+	}
+}
+
+// 補助テスト: ToResponse(nil, ...) が INTERNAL_ERROR + 既定メッセージを返す。
+func TestToResponse_NilFallback(t *testing.T) {
+	resp := apperror.ToResponse(nil, "req-nil")
+	if resp.Code != apperror.CodeInternalError {
+		t.Errorf("Code = %v, want %v", resp.Code, apperror.CodeInternalError)
+	}
+	if resp.Message != apperror.MessageInternalError {
+		t.Errorf("Message = %v, want default", resp.Message)
+	}
+	if resp.RequestID != "req-nil" {
+		t.Errorf("RequestID = %v", resp.RequestID)
+	}
+}
+
+// T-52: request_id が空文字でも JSON は valid。
+func TestToResponse_EmptyRequestID(t *testing.T) {
+	e := apperror.New("INTERNAL_ERROR", "内部エラー")
+	resp := apperror.ToResponse(e, "")
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	v, ok := got["request_id"]
+	if !ok {
+		t.Errorf("request_id field should be present (mandatory), got missing")
+	}
+	if v != "" {
+		t.Errorf("request_id = %v, want empty string", v)
+	}
+}
+
+// 補助テスト: WriteJSON が status / Content-Type / body を正しく書き込む。
+func TestWriteJSON(t *testing.T) {
+	e := apperror.New("NOT_FOUND", "見つかりません")
+	rec := httptest.NewRecorder()
+
+	if err := apperror.WriteJSON(rec, http.StatusNotFound, e, "req-w"); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", res.StatusCode)
+	}
+	if ct := res.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got["code"] != "NOT_FOUND" || got["request_id"] != "req-w" {
+		t.Errorf("body unexpected: %v", got)
+	}
+}

--- a/core/internal/apperror/response.go
+++ b/core/internal/apperror/response.go
@@ -1,0 +1,51 @@
+package apperror
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Response は F-7 基本形のエラーレスポンス JSON。
+//
+// request_id は middleware 層で context から取得して詰める責務 (logger.RequestIDFrom)。
+type Response struct {
+	Code      string         `json:"code"`
+	Message   string         `json:"message"`
+	Details   map[string]any `json:"details,omitempty"`
+	RequestID string         `json:"request_id"`
+}
+
+// MessageInternalError は CodeInternalError 用のデフォルトメッセージ。
+// nil フォールバック時に F-7 の必須フィールド message を空にしないため。
+const MessageInternalError = "内部エラーが発生しました"
+
+// ToResponse は CodedError を Response に変換する。
+//
+// e が nil の場合は INTERNAL_ERROR を返す (recover ミドルウェアの最終フォールバック)。
+// その際 message も既定値を埋めて F-7 必須フィールド要件を満たす。
+func ToResponse(e *CodedError, requestID string) Response {
+	if e == nil {
+		return Response{
+			Code:      CodeInternalError,
+			Message:   MessageInternalError,
+			RequestID: requestID,
+		}
+	}
+	return Response{
+		Code:      e.code,
+		Message:   e.message,
+		Details:   cloneDetails(e.details),
+		RequestID: requestID,
+	}
+}
+
+// WriteJSON は w にエラーレスポンスを書き込む。
+//
+// Content-Type を application/json に設定し、json.Encoder で改行付き 1 行を書き込む。
+// 仕様 F-1 のログインジェクション対策として、本関数は string を直接連結せず必ず
+// encoding/json 経由で出力する。
+func WriteJSON(w http.ResponseWriter, status int, e *CodedError, requestID string) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	return json.NewEncoder(w).Encode(ToResponse(e, requestID))
+}

--- a/core/internal/logger/context.go
+++ b/core/internal/logger/context.go
@@ -1,0 +1,65 @@
+// 責務境界 (F-3 / F-4 必須付与の保証):
+//
+// logger パッケージは "context に id があれば自動付与する" consumer 責務までを持つ。
+// "HTTP 経路の全ログレコードに request_id を付与する" 必須性は、HTTP middleware 側で
+// 全リクエスト境界に WithRequestID を呼ぶことで保証する (Issue #13 / P2 で実装)。
+// 同様に "非 HTTP 経路で event_id 必須付与" は cmd/main やジョブランナー側の責務
+// (起動時に WithEventID 済みの ctx を後段に渡す)。
+//
+// logger 側で未設定検知して fail loud しないのは、"何が HTTP 経路か" を logger が
+// 識別する手段がなく (cmd / ジョブ / テスト等は request_id を持たない方が正常)、
+// 自動採番すると middleware の取り違え (異なるリクエストに同一 ID) を隠蔽するため。
+package logger
+
+import "context"
+
+// ctxKey は context.Context のキーとして使う非公開型。
+// string ではなく独立した型を使うことで他パッケージとのキー衝突を避ける (Go 慣例)。
+type ctxKey struct{ name string }
+
+var (
+	requestIDKey = ctxKey{"request_id"}
+	eventIDKey   = ctxKey{"event_id"}
+)
+
+// WithRequestID は ctx に HTTP リクエスト ID (UUID v7) を載せた派生 context を返す。
+// 仕様 F-3: HTTP 経路の全ログレコードに request_id 必須付与。
+func WithRequestID(ctx context.Context, id string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, requestIDKey, id)
+}
+
+// RequestIDFrom は ctx から request_id を取り出す。未設定または非 string の場合は空文字。
+// nil context を防御的に許容する (panic しない)。
+func RequestIDFrom(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(requestIDKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// WithEventID は ctx に非 HTTP 経路用イベント ID (UUID v7) を載せた派生 context を返す。
+// 仕様 F-4: HTTP 経路外のログレコードには event_id 必須付与 (起動毎・ジョブ毎の一意 ID)。
+func WithEventID(ctx context.Context, id string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, eventIDKey, id)
+}
+
+// EventIDFrom は ctx から event_id を取り出す。未設定または非 string の場合は空文字。
+// nil context を防御的に許容する (panic しない)。
+func EventIDFrom(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(eventIDKey).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/core/internal/logger/context_internal_test.go
+++ b/core/internal/logger/context_internal_test.go
@@ -1,0 +1,26 @@
+package logger
+
+// 内部キー requestIDKey / eventIDKey に直接 string 以外を入れて、
+// RequestIDFrom / EventIDFrom の型アサーション失敗パスが空文字を返すことを直接検証する。
+// (外部テストパッケージからは internal キーへ書き込めないため、本テストのみ package logger 側に置く)
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRequestIDFrom_TypeAssertFailure_ReturnsEmpty(t *testing.T) {
+	ctx := context.WithValue(context.Background(), requestIDKey, 12345) // 非 string
+
+	if got := RequestIDFrom(ctx); got != "" {
+		t.Errorf("RequestIDFrom (non-string value) = %q, want empty", got)
+	}
+}
+
+func TestEventIDFrom_TypeAssertFailure_ReturnsEmpty(t *testing.T) {
+	ctx := context.WithValue(context.Background(), eventIDKey, struct{}{}) // 非 string
+
+	if got := EventIDFrom(ctx); got != "" {
+		t.Errorf("EventIDFrom (non-string value) = %q, want empty", got)
+	}
+}

--- a/core/internal/logger/context_test.go
+++ b/core/internal/logger/context_test.go
@@ -1,0 +1,131 @@
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+// T-6: WithRequestID -> RequestIDFrom で値が往復する。
+func TestContext_RequestID_RoundTrip(t *testing.T) {
+	ctx := logger.WithRequestID(context.Background(), "01911f4e-7234-7b2a-8000-000000000001")
+	if got := logger.RequestIDFrom(ctx); got != "01911f4e-7234-7b2a-8000-000000000001" {
+		t.Errorf("RequestIDFrom = %q, want UUIDv7", got)
+	}
+}
+
+// T-7: WithEventID -> EventIDFrom で値が往復する。
+func TestContext_EventID_RoundTrip(t *testing.T) {
+	ctx := logger.WithEventID(context.Background(), "01911f4e-7234-7b2a-8000-000000000002")
+	if got := logger.EventIDFrom(ctx); got != "01911f4e-7234-7b2a-8000-000000000002" {
+		t.Errorf("EventIDFrom = %q, want UUIDv7", got)
+	}
+}
+
+// T-8: 未設定の context から取得しても panic せず空文字を返す。
+func TestContext_MissingID_ReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	if got := logger.RequestIDFrom(ctx); got != "" {
+		t.Errorf("RequestIDFrom (missing) = %q, want empty", got)
+	}
+	if got := logger.EventIDFrom(ctx); got != "" {
+		t.Errorf("EventIDFrom (missing) = %q, want empty", got)
+	}
+}
+
+// 補助テスト: 非 string 型の値が ctx に入っていても panic せず空文字を返す。
+// 通常は WithRequestID 経由でしか書けないが、防御的型アサーションの retreat path を担保する。
+func TestContext_NonStringValue_ReturnsEmpty(t *testing.T) {
+	// 同じキー型で別の型の値を入れるには内部キーへのアクセスが必要だが、
+	// ここでは同名の独自キーで context を汚染しても影響しないことを確認するに留める。
+	type unrelatedKey struct{ name string }
+	ctx := context.WithValue(context.Background(), unrelatedKey{"request_id"}, 12345)
+
+	if got := logger.RequestIDFrom(ctx); got != "" {
+		t.Errorf("RequestIDFrom should be insulated from unrelated keys, got: %q", got)
+	}
+	if got := logger.EventIDFrom(ctx); got != "" {
+		t.Errorf("EventIDFrom should be insulated from unrelated keys, got: %q", got)
+	}
+}
+
+// 補助テスト: nil context でも panic しない (防御)。
+func TestContext_NilContext_NoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RequestIDFrom panicked on nil ctx: %v", r)
+		}
+	}()
+	//nolint:staticcheck // nil context の防御挙動を直接検証する目的。
+	if got := logger.RequestIDFrom(nil); got != "" {
+		t.Errorf("RequestIDFrom(nil) = %q, want empty", got)
+	}
+	if got := logger.EventIDFrom(nil); got != "" {
+		t.Errorf("EventIDFrom(nil) = %q, want empty", got)
+	}
+}
+
+// T-9 (a): logger.Info 経由で context の request_id が自動付与される (HTTP 経路想定)。
+func TestLogger_AutoAttachesRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+	ctx := logger.WithRequestID(context.Background(), "req-abc")
+
+	l.Info(ctx, "handled")
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &m); err != nil {
+		t.Fatalf("Unmarshal: %v (out=%q)", err, buf.String())
+	}
+	if got := m["request_id"]; got != "req-abc" {
+		t.Errorf("request_id = %v, want req-abc", got)
+	}
+	if _, hasEvent := m["event_id"]; hasEvent {
+		t.Errorf("event_id should not be present when only request_id is set, got: %v", m["event_id"])
+	}
+}
+
+// T-9 (b): logger.Info 経由で context の event_id が自動付与される (非 HTTP 経路想定)。
+func TestLogger_AutoAttachesEventID(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+	ctx := logger.WithEventID(context.Background(), "evt-xyz")
+
+	l.Info(ctx, "background-job")
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := m["event_id"]; got != "evt-xyz" {
+		t.Errorf("event_id = %v, want evt-xyz", got)
+	}
+	if _, hasReq := m["request_id"]; hasReq {
+		t.Errorf("request_id should not be present when only event_id is set, got: %v", m["request_id"])
+	}
+}
+
+// 補助テスト: id 未設定の context から出力すると、request_id / event_id どちらも attr に
+// 含まれない (空文字で誤って付与しない)。
+func TestLogger_NoAutoAttachWhenContextEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+
+	l.Info(context.Background(), "no-ctx-ids")
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := m["request_id"]; ok {
+		t.Errorf("request_id should be omitted when ctx has none, got: %v", m["request_id"])
+	}
+	if _, ok := m["event_id"]; ok {
+		t.Errorf("event_id should be omitted when ctx has none, got: %v", m["event_id"])
+	}
+}

--- a/core/internal/logger/fallback.go
+++ b/core/internal/logger/fallback.go
@@ -1,0 +1,73 @@
+package logger
+
+import (
+	"io"
+	"os"
+	"sync/atomic"
+)
+
+// FallbackWriter は primary writer の書き込み失敗時に fallback writer (デフォルト stderr) へ
+// フォールバックする io.Writer。fallback も失敗した場合は drop counter を増分する (Q9)。
+//
+// Write は呼び出し元にエラーを返さない: ログ出力失敗でリクエスト処理を止めない方針。
+// drop counter は内部保持し、外部公開は M1.x のメトリクス連携で行う (DropCount で取得可)。
+type FallbackWriter struct {
+	primary  io.Writer
+	fallback io.Writer
+	drops    atomic.Int64
+}
+
+// NewFallbackWriter は primary を wrap し、fallback として os.Stderr を設定した
+// FallbackWriter を返す。
+func NewFallbackWriter(primary io.Writer) *FallbackWriter {
+	return &FallbackWriter{
+		primary:  primary,
+		fallback: os.Stderr,
+	}
+}
+
+// Write は primary -> fallback の順に書き込みを試みる。
+//
+// 戻り値は常に nil error: ログ出力の失敗を呼び出し元 (Logger.log -> handler.Handle) に
+// 伝播させない。
+//
+// io.Writer 契約への配慮:
+//   - primary が部分書き込み + error (n > 0 && err != nil) を返した場合は、
+//     fallback には残り p[n:] のみを書き込み、二重出力を防ぐ。
+//   - fallback も同様に部分書き込みを許容する (n が len(残り) と異なってもエラー扱い)。
+//
+// 戻り値:
+//   - primary が完了したら primary の n を返す。
+//   - 部分書き込みを fallback で補完できたら (primary n) + (fallback n) を返す。
+//   - 両方失敗した場合は len(p) を返して drop counter を 1 増分する
+//     (バイト数は呼び出し側のループ条件を壊さないため正の値で返す)。
+func (w *FallbackWriter) Write(p []byte) (int, error) {
+	pn, perr := w.primary.Write(p)
+	if perr == nil {
+		return pn, nil
+	}
+
+	// 部分書き込み: primary が pn バイト書いた後にエラーになった場合は、
+	// 残り p[pn:] のみを fallback に渡す (重複出力防止)。
+	// pn の範囲は不正実装に備えて [0, len(p)] にクランプする (slice panic 回避)。
+	if pn < 0 {
+		pn = 0
+	}
+	if pn > len(p) {
+		pn = len(p)
+	}
+	remaining := p[pn:]
+	fn, ferr := w.fallback.Write(remaining)
+	if ferr == nil && fn == len(remaining) {
+		return pn + fn, nil
+	}
+
+	w.drops.Add(1)
+	return len(p), nil
+}
+
+// DropCount は primary / fallback 両方失敗してドロップしたレコード数を返す (atomic 取得)。
+// M1.x のメトリクスエンドポイントから参照する想定。
+func (w *FallbackWriter) DropCount() int64 {
+	return w.drops.Load()
+}

--- a/core/internal/logger/fallback_test.go
+++ b/core/internal/logger/fallback_test.go
@@ -1,0 +1,162 @@
+package logger
+
+// FallbackWriter は内部 writer の挙動をテストする必要があるため、
+// 内部テストパッケージ (package logger) に置き、stderr 注入経路を直接検証する。
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// failingWriter は任意のエラーを返すモック writer。calls は呼び出し回数 (atomic)。
+type failingWriter struct {
+	err   error
+	calls atomic.Int64
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.calls.Add(1)
+	return 0, f.err
+}
+
+// T-19: primary が失敗した場合、stderr (fallback) に書き込み、Write 呼び出し元には
+// エラーを伝播しない (リクエスト処理は継続)。
+func TestFallbackWriter_PrimaryFails_FallsBackToStderr(t *testing.T) {
+	primary := &failingWriter{err: errors.New("disk full")}
+	var stderrBuf bytes.Buffer
+
+	fw := &FallbackWriter{primary: primary, fallback: &stderrBuf}
+
+	n, err := fw.Write([]byte(`{"msg":"hello"}` + "\n"))
+	if err != nil {
+		t.Errorf("Write should not propagate error to caller, got: %v", err)
+	}
+	if n == 0 {
+		t.Errorf("Write should report bytes written (>0), got %d", n)
+	}
+	if stderrBuf.Len() == 0 {
+		t.Errorf("fallback (stderr) should have received the bytes, got empty")
+	}
+	if got := fw.DropCount(); got != 0 {
+		t.Errorf("DropCount = %d, want 0 (fallback succeeded)", got)
+	}
+}
+
+// T-20: primary / fallback 両方失敗時に DropCount が増分し、Write はエラーを返さない。
+func TestFallbackWriter_BothFail_IncrementDropCount(t *testing.T) {
+	primary := &failingWriter{err: errors.New("p down")}
+	fallback := &failingWriter{err: errors.New("f down")}
+
+	fw := &FallbackWriter{primary: primary, fallback: fallback}
+
+	for i := 0; i < 3; i++ {
+		if _, err := fw.Write([]byte("x")); err != nil {
+			t.Errorf("Write should not propagate error even when both fail, got: %v", err)
+		}
+	}
+
+	if got := fw.DropCount(); got != 3 {
+		t.Errorf("DropCount after 3 failures = %d, want 3", got)
+	}
+}
+
+// T-21: primary が正常な場合、fallback は呼ばれず DropCount は 0。
+func TestFallbackWriter_PrimaryOK_NoDropAndNoFallback(t *testing.T) {
+	var primary bytes.Buffer
+	fallback := &failingWriter{err: errors.New("should-not-be-called")}
+
+	fw := &FallbackWriter{primary: &primary, fallback: fallback}
+
+	for i := 0; i < 5; i++ {
+		if _, err := fw.Write([]byte("ok")); err != nil {
+			t.Errorf("Write error: %v", err)
+		}
+	}
+
+	if got := fw.DropCount(); got != 0 {
+		t.Errorf("DropCount = %d, want 0 (primary succeeded)", got)
+	}
+	if c := fallback.calls.Load(); c != 0 {
+		t.Errorf("fallback should not be called when primary succeeds, got %d calls", c)
+	}
+}
+
+// 補助テスト: NewFallbackWriter は os.Stderr を fallback として設定する。
+func TestNewFallbackWriter_DefaultsToStderr(t *testing.T) {
+	var primary bytes.Buffer
+	fw := NewFallbackWriter(&primary)
+
+	if fw.primary != &primary {
+		t.Errorf("primary not wired correctly")
+	}
+	if fw.fallback != os.Stderr {
+		t.Errorf("fallback should be os.Stderr, got %T %v", fw.fallback, fw.fallback)
+	}
+}
+
+// partialWriter は最初に halfBytes だけ書いて error を返すモック writer (io.Writer 契約)。
+type partialWriter struct {
+	halfBytes int
+	err       error
+}
+
+func (p *partialWriter) Write(buf []byte) (int, error) {
+	n := p.halfBytes
+	if n > len(buf) {
+		n = len(buf)
+	}
+	return n, p.err
+}
+
+// 補助テスト: primary が部分書き込み + error を返した場合、fallback は残りバイトのみ
+// 書き込み、Write の戻り値は primary + fallback の合計バイト数になる。
+func TestFallbackWriter_PartialPrimaryWrite_NoDuplication(t *testing.T) {
+	primary := &partialWriter{halfBytes: 4, err: errors.New("disk-cut-off")}
+	var fallback bytes.Buffer
+
+	fw := &FallbackWriter{primary: primary, fallback: &fallback}
+
+	payload := []byte("0123456789") // 10 bytes
+	n, err := fw.Write(payload)
+	if err != nil {
+		t.Fatalf("Write should not propagate error, got: %v", err)
+	}
+	if n != len(payload) {
+		t.Errorf("Write n = %d, want %d (primary 4 + fallback 6)", n, len(payload))
+	}
+	if got := fallback.String(); got != "456789" {
+		t.Errorf("fallback should receive only the remaining bytes, got: %q", got)
+	}
+	if got := fw.DropCount(); got != 0 {
+		t.Errorf("DropCount = %d, want 0 (fallback completed remainder)", got)
+	}
+}
+
+// 補助テスト: 並行書き込み下でも DropCount が atomic に増分される。
+func TestFallbackWriter_ConcurrentDrops(t *testing.T) {
+	primary := &failingWriter{err: errors.New("p")}
+	fallback := &failingWriter{err: errors.New("f")}
+	fw := &FallbackWriter{primary: primary, fallback: fallback}
+
+	const writers = 10
+	const iterations = 100
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_, _ = fw.Write([]byte("x"))
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := fw.DropCount(), int64(writers*iterations); got != want {
+		t.Errorf("DropCount = %d, want %d (atomic miscount?)", got, want)
+	}
+}

--- a/core/internal/logger/format.go
+++ b/core/internal/logger/format.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// Format はログ出力フォーマット種別。
+type Format int
+
+const (
+	// FormatJSON は JSON Lines 形式 (本番想定)。
+	FormatJSON Format = iota
+	// FormatText は key=value 形式 (開発時用)。
+	FormatText
+)
+
+const envLogFormat = "CORE_LOG_FORMAT"
+
+// FormatFromEnv は CORE_LOG_FORMAT 環境変数からフォーマットを決定する。
+//
+// 値が未設定または "json" のとき FormatJSON、"text" のとき FormatText を返す。
+// それ以外はエラー。
+func FormatFromEnv() (Format, error) {
+	v := os.Getenv(envLogFormat)
+	switch v {
+	case "", "json":
+		return FormatJSON, nil
+	case "text":
+		return FormatText, nil
+	default:
+		return 0, fmt.Errorf("logger: 不正な %s の値: %q (json|text のみ受け付ける)", envLogFormat, v)
+	}
+}
+
+// utcTimeReplaceAttr は slog.HandlerOptions.ReplaceAttr フックで time フィールドを
+// UTC + RFC3339Nano に変換する。プロセス全体の time.Local を変更する副作用を避ける目的。
+func utcTimeReplaceAttr(_ []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey && a.Value.Kind() == slog.KindTime {
+		a.Value = slog.StringValue(a.Value.Time().UTC().Format(time.RFC3339Nano))
+	}
+	return a
+}
+
+// newHandler は format に応じた slog.Handler を生成する。
+// Level は LevelDebug (使い分けは Q7 に従い、本番では DEBUG を出さない運用とする)。
+func newHandler(format Format, w io.Writer) slog.Handler {
+	opts := &slog.HandlerOptions{
+		Level:       slog.LevelDebug,
+		ReplaceAttr: utcTimeReplaceAttr,
+	}
+	switch format {
+	case FormatText:
+		return slog.NewTextHandler(w, opts)
+	default:
+		return slog.NewJSONHandler(w, opts)
+	}
+}

--- a/core/internal/logger/logger.go
+++ b/core/internal/logger/logger.go
@@ -1,0 +1,64 @@
+// Package logger は id-core 用の構造化ログ出力 API を提供する。
+//
+// 設計判断 (D2): slog.Logger を直接公開せず、薄い独自インターフェースで包む。
+// これにより context から request_id / event_id を自動付与し (Step 3 で実装)、
+// Domain 層からロガーを直接呼ばない規約 (F-14) を境界 API レベルで自然化する。
+package logger
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"time"
+)
+
+// Logger は本プロジェクトのログ出力 API。
+//
+// 内部実装は slog.Handler。
+type Logger struct {
+	handler slog.Handler
+}
+
+// New は format / writer を指定して Logger を生成する。
+func New(format Format, w io.Writer) *Logger {
+	return &Logger{handler: newHandler(format, w)}
+}
+
+// Info は INFO レベルでログを出力する (業務イベント)。
+func (l *Logger) Info(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelInfo, msg, nil, args...)
+}
+
+// Warn は WARN レベルでログを出力する (4xx 等)。
+func (l *Logger) Warn(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelWarn, msg, nil, args...)
+}
+
+// Error は ERROR レベルでログを出力する (5xx / panic / 予期しないエラー)。
+//
+// err は別引数で受け、構造化フィールド "error" として付与する (string 連結で
+// 改行・制御文字を混入させないため、F-1 のログインジェクション対策)。
+func (l *Logger) Error(ctx context.Context, msg string, err error, args ...any) {
+	l.log(ctx, slog.LevelError, msg, err, args...)
+}
+
+// Debug は DEBUG レベルでログを出力する (本番無効・開発調査用)。
+func (l *Logger) Debug(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelDebug, msg, nil, args...)
+}
+
+func (l *Logger) log(ctx context.Context, level slog.Level, msg string, errVal error, args ...any) {
+	if !l.handler.Enabled(ctx, level) {
+		return
+	}
+	r := slog.NewRecord(time.Now(), level, msg, 0)
+	r.Add(args...)
+	if errVal != nil {
+		r.AddAttrs(slog.String("error", errVal.Error()))
+	}
+	// Handle のエラーは Step 5 (fallback.go) の FallbackWriter で吸収する。
+	// ここで返されるのは writer 側のエラー (stdout 書き込み失敗等) で、
+	// FallbackWriter が stderr フォールバック + drop counter で記録するため、
+	// Logger.log としてはエラーを呼び出し元に伝播せず継続する (リクエスト処理を止めない)。
+	_ = l.handler.Handle(ctx, r)
+}

--- a/core/internal/logger/logger.go
+++ b/core/internal/logger/logger.go
@@ -48,10 +48,25 @@ func (l *Logger) Debug(ctx context.Context, msg string, args ...any) {
 }
 
 func (l *Logger) log(ctx context.Context, level slog.Level, msg string, errVal error, args ...any) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !l.handler.Enabled(ctx, level) {
 		return
 	}
 	r := slog.NewRecord(time.Now(), level, msg, 0)
+
+	// F-3 / F-4: context から request_id / event_id を取得して付与。
+	// HTTP 経路 (middleware が WithRequestID 済み) -> request_id 付与。
+	// 非 HTTP 経路 (起動・ジョブ等が WithEventID 済み) -> event_id 付与。
+	// どちらも未設定の場合は付与しない (誤って空文字を入れない)。
+	if id := RequestIDFrom(ctx); id != "" {
+		r.AddAttrs(slog.String("request_id", id))
+	}
+	if id := EventIDFrom(ctx); id != "" {
+		r.AddAttrs(slog.String("event_id", id))
+	}
+
 	r.Add(args...)
 	if errVal != nil {
 		r.AddAttrs(slog.String("error", errVal.Error()))

--- a/core/internal/logger/logger.go
+++ b/core/internal/logger/logger.go
@@ -20,8 +20,11 @@ type Logger struct {
 }
 
 // New は format / writer を指定して Logger を生成する。
+//
+// w は内部で FallbackWriter にラップされ、書き込み失敗時に stderr へフォールバックする
+// (Q9 仕様)。テストで bytes.Buffer を渡す場合は失敗経路に入らないため挙動は同一。
 func New(format Format, w io.Writer) *Logger {
-	return &Logger{handler: newHandler(format, w)}
+	return &Logger{handler: newHandler(format, NewFallbackWriter(w))}
 }
 
 // Info は INFO レベルでログを出力する (業務イベント)。

--- a/core/internal/logger/logger_test.go
+++ b/core/internal/logger/logger_test.go
@@ -1,0 +1,166 @@
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+// T-1: CORE_LOG_FORMAT=json (デフォルト) で 1 行 JSON が time/level/msg を含む。
+func TestLogger_JSONFormat_Default(t *testing.T) {
+	t.Setenv("CORE_LOG_FORMAT", "")
+
+	f, err := logger.FormatFromEnv()
+	if err != nil {
+		t.Fatalf("FormatFromEnv: %v", err)
+	}
+	if f != logger.FormatJSON {
+		t.Fatalf("default format = %v, want JSON", f)
+	}
+
+	var buf bytes.Buffer
+	l := logger.New(f, &buf)
+	l.Info(context.Background(), "test-msg")
+
+	out := strings.TrimSpace(buf.String())
+	if !strings.HasPrefix(out, "{") || !strings.HasSuffix(out, "}") {
+		t.Fatalf("output should be 1-line JSON, got: %q", out)
+	}
+	if strings.Count(out, "\n") != 0 {
+		t.Errorf("output should be single line, got newlines: %q", out)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("Unmarshal: %v (out=%q)", err, out)
+	}
+	for _, k := range []string{"time", "level", "msg"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing key %q in output: %v", k, m)
+		}
+	}
+	if m["msg"] != "test-msg" {
+		t.Errorf("msg = %v, want test-msg", m["msg"])
+	}
+}
+
+// T-2: CORE_LOG_FORMAT=text で key=value 形式が出る。
+func TestLogger_TextFormat(t *testing.T) {
+	t.Setenv("CORE_LOG_FORMAT", "text")
+
+	f, err := logger.FormatFromEnv()
+	if err != nil {
+		t.Fatalf("FormatFromEnv: %v", err)
+	}
+	if f != logger.FormatText {
+		t.Fatalf("format = %v, want Text", f)
+	}
+
+	var buf bytes.Buffer
+	l := logger.New(f, &buf)
+	l.Info(context.Background(), "hello")
+
+	out := strings.TrimSpace(buf.String())
+	if !strings.Contains(out, "msg=hello") {
+		t.Errorf("text format should contain msg=hello, got: %q", out)
+	}
+	if !strings.Contains(out, "level=INFO") {
+		t.Errorf("text format should contain level=INFO, got: %q", out)
+	}
+	// JSON 形式ではないこと。
+	if strings.HasPrefix(out, "{") {
+		t.Errorf("text format should not start with '{', got: %q", out)
+	}
+}
+
+// T-3: CORE_LOG_FORMAT=invalid でエラー。
+func TestFormatFromEnv_Invalid(t *testing.T) {
+	t.Setenv("CORE_LOG_FORMAT", "yaml")
+
+	_, err := logger.FormatFromEnv()
+	if err == nil {
+		t.Fatalf("expected error for invalid value, got nil")
+	}
+	if !strings.Contains(err.Error(), "CORE_LOG_FORMAT") {
+		t.Errorf("error should mention CORE_LOG_FORMAT, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("error should mention the bad value 'yaml', got: %v", err)
+	}
+}
+
+// T-4: time フィールドが RFC3339Nano UTC (Z suffix)。
+func TestLogger_TimeFormat_UTCRFC3339Nano(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+	l.Info(context.Background(), "x")
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	timeStr, ok := m["time"].(string)
+	if !ok {
+		t.Fatalf("time field not string, got %T", m["time"])
+	}
+	if !strings.HasSuffix(timeStr, "Z") {
+		t.Errorf("time should have Z suffix (UTC), got: %q", timeStr)
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, timeStr)
+	if err != nil {
+		t.Fatalf("time should parse as RFC3339Nano: %v (got: %q)", err, timeStr)
+	}
+	if parsed.Location() != time.UTC {
+		t.Errorf("parsed location = %v, want UTC", parsed.Location())
+	}
+}
+
+// 補助テスト: Error() が "error" フィールドを構造化 attr として付与し、
+// 改行・制御文字を含むエラー文字列も JSON エンコーダ経由で安全にエスケープされる
+// (F-1 ログインジェクション対策の確認)。
+func TestLogger_Error_StructuredAndSafe(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+	injected := errors.New("malicious\n\"injected\"\x00line")
+	l.Error(context.Background(), "boom", injected)
+
+	out := strings.TrimSpace(buf.String())
+	// 改行が JSON 文字列リテラル内で 1 行に収まっていること (= JSON が破壊されていない)。
+	if strings.Count(out, "\n") != 0 {
+		t.Errorf("output should be single line, got newlines: %q", out)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("Unmarshal: %v (out=%q)", err, out)
+	}
+	if got := m["msg"]; got != "boom" {
+		t.Errorf("msg = %v, want boom", got)
+	}
+	if got, ok := m["error"].(string); !ok {
+		t.Fatalf("error field should be string, got %T", m["error"])
+	} else if got != injected.Error() {
+		t.Errorf("error field = %q, want %q (round-trip via JSON encoder)", got, injected.Error())
+	}
+	if m["level"] != "ERROR" {
+		t.Errorf("level = %v, want ERROR", m["level"])
+	}
+}
+
+// T-5: ロガー初期化前後で time.Local が変化していない (プロセス全体への副作用なし)。
+func TestLogger_NoSideEffectOnTimeLocal(t *testing.T) {
+	before := time.Local
+
+	var buf bytes.Buffer
+	_ = logger.New(logger.FormatJSON, &buf)
+
+	if time.Local != before {
+		t.Errorf("time.Local mutated by logger init: before=%v after=%v", before, time.Local)
+	}
+}

--- a/core/internal/logger/redact.go
+++ b/core/internal/logger/redact.go
@@ -9,9 +9,12 @@ import (
 // 長さや存在情報を漏らさないため "****" 等のマスキングではなく固定文字列で置換する (Q8)。
 const RedactedValue = "[REDACTED]"
 
-// HeaderKeysToRedact は HTTP リクエストヘッダの redact 対象 (Q8)。
+// headerKeysToRedact は HTTP リクエストヘッダの redact 対象 (Q8)。
 // 照合は case-insensitive。
-var HeaderKeysToRedact = []string{
+//
+// 非公開: 外部から書き換えられて redact が無効化される事故を防ぐ。
+// 設定変更が必要になった場合は本パッケージ内で更新する (リリースに含める)。
+var headerKeysToRedact = []string{
 	"Authorization",
 	"Cookie",
 	"Set-Cookie",
@@ -20,9 +23,11 @@ var HeaderKeysToRedact = []string{
 	"X-Auth-Token",
 }
 
-// FieldKeysToRedact は body / query / form / details の redact 対象 (Q8)。
+// fieldKeysToRedact は body / query / form / details の redact 対象 (Q8)。
 // 照合は case-insensitive かつ完全一致 (部分一致禁止)。
-var FieldKeysToRedact = []string{
+//
+// 非公開: 外部から書き換えられて redact が無効化される事故を防ぐ。
+var fieldKeysToRedact = []string{
 	"password",
 	"current_password",
 	"new_password",
@@ -44,8 +49,8 @@ var FieldKeysToRedact = []string{
 // 内部で使う照合用 set (lower-case 化済み)。
 // init で生成し、以降の Redact* 呼び出し中の I/O を抑える。
 var (
-	headerKeysSet = buildLowerSet(HeaderKeysToRedact)
-	fieldKeysSet  = buildLowerSet(FieldKeysToRedact)
+	headerKeysSet = buildLowerSet(headerKeysToRedact)
+	fieldKeysSet  = buildLowerSet(fieldKeysToRedact)
 )
 
 func buildLowerSet(keys []string) map[string]struct{} {

--- a/core/internal/logger/redact.go
+++ b/core/internal/logger/redact.go
@@ -1,0 +1,124 @@
+package logger
+
+import (
+	"net/http"
+	"strings"
+)
+
+// RedactedValue は redact 対象を置換する固定値。
+// 長さや存在情報を漏らさないため "****" 等のマスキングではなく固定文字列で置換する (Q8)。
+const RedactedValue = "[REDACTED]"
+
+// HeaderKeysToRedact は HTTP リクエストヘッダの redact 対象 (Q8)。
+// 照合は case-insensitive。
+var HeaderKeysToRedact = []string{
+	"Authorization",
+	"Cookie",
+	"Set-Cookie",
+	"Proxy-Authorization",
+	"X-Api-Key",
+	"X-Auth-Token",
+}
+
+// FieldKeysToRedact は body / query / form / details の redact 対象 (Q8)。
+// 照合は case-insensitive かつ完全一致 (部分一致禁止)。
+var FieldKeysToRedact = []string{
+	"password",
+	"current_password",
+	"new_password",
+	"access_token",
+	"refresh_token",
+	"id_token",
+	"code",
+	"code_verifier",
+	"client_secret",
+	"assertion",
+	"client_assertion",
+	"private_key",
+	"secret",
+	"api_key",
+	"jwt",
+	"bearer_token",
+}
+
+// 内部で使う照合用 set (lower-case 化済み)。
+// init で生成し、以降の Redact* 呼び出し中の I/O を抑える。
+var (
+	headerKeysSet = buildLowerSet(HeaderKeysToRedact)
+	fieldKeysSet  = buildLowerSet(FieldKeysToRedact)
+)
+
+func buildLowerSet(keys []string) map[string]struct{} {
+	s := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		s[strings.ToLower(k)] = struct{}{}
+	}
+	return s
+}
+
+// RedactHeaders は HTTP ヘッダのディープコピーを作り、deny-list キーの値を [REDACTED] に
+// 置換する (Q8)。元の http.Header は変更しない (immutable)。
+//
+// nil を渡すと nil を返す。
+func RedactHeaders(h http.Header) http.Header {
+	if h == nil {
+		return nil
+	}
+	out := make(http.Header, len(h))
+	for k, v := range h {
+		if _, hit := headerKeysSet[strings.ToLower(k)]; hit {
+			redacted := make([]string, len(v))
+			for i := range v {
+				redacted[i] = RedactedValue
+			}
+			out[k] = redacted
+			continue
+		}
+		// 値スライスのコピー (元 slice の変更が反映されないように)。
+		cp := make([]string, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
+}
+
+// RedactMap は map[string]any を再帰走査し、deny-list キーの値を [REDACTED] に置換した
+// 新しい map を返す (Q8)。元の map は変更しない (immutable)。
+//
+// 配列内の object も再帰走査する。プリミティブ値はそのまま値渡しで保持。
+// キー照合は case-insensitive かつ完全一致 (部分一致は誤検知防止のため禁止)。
+//
+// 入力前提: encoding/json で Unmarshal した map[string]any (json.Number 含む) を想定。
+// このため再帰対象の slice 型は []any のみ ([]string / []int 等の typed slice は対象外)。
+// 呼び出し元で typed slice を入れる場合、その要素の参照共有は防がない (実害は小)。
+//
+// nil を渡すと nil を返す。
+func RedactMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if _, hit := fieldKeysSet[strings.ToLower(k)]; hit {
+			out[k] = RedactedValue
+			continue
+		}
+		out[k] = redactValue(v)
+	}
+	return out
+}
+
+func redactValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return RedactMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, item := range t {
+			out[i] = redactValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/core/internal/logger/redact_test.go
+++ b/core/internal/logger/redact_test.go
@@ -1,0 +1,298 @@
+package logger_test
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/apperror"
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+// T-10: HTTP ヘッダ Authorization: Bearer xxx を redact。
+func TestRedactHeaders_Authorization(t *testing.T) {
+	h := http.Header{}
+	h.Set("Authorization", "Bearer secret-token")
+	h.Set("X-Trace-Id", "trace-1")
+
+	got := logger.RedactHeaders(h)
+
+	if v := got.Get("Authorization"); v != logger.RedactedValue {
+		t.Errorf("Authorization = %q, want %q", v, logger.RedactedValue)
+	}
+	if v := got.Get("X-Trace-Id"); v != "trace-1" {
+		t.Errorf("X-Trace-Id should not be redacted, got %q", v)
+	}
+}
+
+// T-11: ヘッダ照合は case-insensitive。
+func TestRedactHeaders_CaseInsensitive(t *testing.T) {
+	// http.Header.Set は標準的に Title-Case 化するので、Add で生 case を入れる。
+	h := http.Header{
+		"authorization":       []string{"bearer xxx"},
+		"AUTHORIZATION":       []string{"BEARER yyy"},
+		"Proxy-Authorization": []string{"Basic zzz"},
+	}
+
+	got := logger.RedactHeaders(h)
+
+	for k, vs := range got {
+		for _, v := range vs {
+			if v != logger.RedactedValue {
+				t.Errorf("header %q value %q should be redacted", k, v)
+			}
+		}
+	}
+}
+
+// T-16: redact 対象キーの全 6 ヘッダを網羅 (case 違いも含めて)。
+func TestRedactHeaders_AllDenyListed(t *testing.T) {
+	cases := []string{
+		"Authorization",
+		"Cookie",
+		"Set-Cookie",
+		"Proxy-Authorization",
+		"X-Api-Key",
+		"X-Auth-Token",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := http.Header{}
+			h.Set(name, "secret-value")
+			got := logger.RedactHeaders(h)
+			if v := got.Get(name); v != logger.RedactedValue {
+				t.Errorf("%s = %q, want %q", name, v, logger.RedactedValue)
+			}
+		})
+	}
+}
+
+// T-12: JSON body {"password": "secret"} を redact。
+func TestRedactMap_PasswordTopLevel(t *testing.T) {
+	in := map[string]any{"password": "secret", "username": "alice"}
+	got := logger.RedactMap(in)
+
+	if got["password"] != logger.RedactedValue {
+		t.Errorf("password should be redacted, got %v", got["password"])
+	}
+	if got["username"] != "alice" {
+		t.Errorf("username should not be touched, got %v", got["username"])
+	}
+
+	// 元の map は変更されていない (immutable)。
+	if in["password"] != "secret" {
+		t.Errorf("source map mutated: %v", in)
+	}
+}
+
+// T-13: ネストした JSON で client_secret が走査される。
+func TestRedactMap_NestedObject(t *testing.T) {
+	in := map[string]any{
+		"outer": map[string]any{
+			"client_secret": "shh",
+			"client_id":     "public",
+		},
+	}
+	got := logger.RedactMap(in)
+
+	outer, ok := got["outer"].(map[string]any)
+	if !ok {
+		t.Fatalf("outer should be map[string]any, got %T", got["outer"])
+	}
+	if outer["client_secret"] != logger.RedactedValue {
+		t.Errorf("client_secret should be redacted, got %v", outer["client_secret"])
+	}
+	if outer["client_id"] != "public" {
+		t.Errorf("client_id should be untouched, got %v", outer["client_id"])
+	}
+}
+
+// T-14: 配列内の object も再帰走査される。
+func TestRedactMap_NestedArray(t *testing.T) {
+	in := map[string]any{
+		"creds": []any{
+			map[string]any{"access_token": "a"},
+			map[string]any{"refresh_token": "b"},
+			"raw-string-element",
+		},
+	}
+	got := logger.RedactMap(in)
+
+	arr, ok := got["creds"].([]any)
+	if !ok || len(arr) != 3 {
+		t.Fatalf("creds should be []any of len 3, got %T", got["creds"])
+	}
+	if arr[0].(map[string]any)["access_token"] != logger.RedactedValue {
+		t.Errorf("creds[0].access_token should be redacted, got %v", arr[0])
+	}
+	if arr[1].(map[string]any)["refresh_token"] != logger.RedactedValue {
+		t.Errorf("creds[1].refresh_token should be redacted, got %v", arr[1])
+	}
+	if arr[2] != "raw-string-element" {
+		t.Errorf("scalar element mutated: %v", arr[2])
+	}
+}
+
+// T-15: redact 対象キー全 16 フィールドを網羅 (case-insensitive 完全一致)。
+func TestRedactMap_AllDenyListedFields(t *testing.T) {
+	keys := []string{
+		"password",
+		"current_password",
+		"new_password",
+		"access_token",
+		"refresh_token",
+		"id_token",
+		"code",
+		"code_verifier",
+		"client_secret",
+		"assertion",
+		"client_assertion",
+		"private_key",
+		"secret",
+		"api_key",
+		"jwt",
+		"bearer_token",
+	}
+	for _, k := range keys {
+		t.Run(k, func(t *testing.T) {
+			in := map[string]any{k: "value-of-" + k}
+			got := logger.RedactMap(in)
+			if got[k] != logger.RedactedValue {
+				t.Errorf("%s should be redacted, got %v", k, got[k])
+			}
+		})
+		// case 違い (大文字化) でも同じ。
+		t.Run(k+" (UPPER)", func(t *testing.T) {
+			upperKey := upper(k)
+			in := map[string]any{upperKey: "value"}
+			got := logger.RedactMap(in)
+			if got[upperKey] != logger.RedactedValue {
+				t.Errorf("%s (upper) should be redacted, got %v", upperKey, got[upperKey])
+			}
+		})
+	}
+}
+
+// T-17: 部分一致禁止 — accessusername は access_token に誤検知しない。
+func TestRedactMap_NoSubstringMatch(t *testing.T) {
+	in := map[string]any{
+		"accessusername":  "alice",  // access_token に部分一致しない
+		"mypassword":      "secret", // password に部分一致しない
+		"client_secret_x": "kept",   // client_secret に部分一致しない
+	}
+	got := logger.RedactMap(in)
+
+	for k, want := range map[string]any{
+		"accessusername":  "alice",
+		"mypassword":      "secret",
+		"client_secret_x": "kept",
+	} {
+		if got[k] != want {
+			t.Errorf("substring match should not redact %q: got %v, want %v", k, got[k], want)
+		}
+	}
+}
+
+// T-18: 対象キーが存在しないとき出力は元の構造のまま (不要な置換なし)。
+func TestRedactMap_NoTarget_NoChange(t *testing.T) {
+	in := map[string]any{
+		"username": "alice",
+		"email":    "a@example.com",
+		"meta": map[string]any{
+			"locale": "ja",
+		},
+	}
+	got := logger.RedactMap(in)
+
+	if !reflect.DeepEqual(in, got) {
+		t.Errorf("map should be unchanged when no deny key matches.\n in=%v\n got=%v", in, got)
+	}
+}
+
+// 補助テスト: RedactHeaders の immutable 保証 — 元の Header と値スライスが
+// 変更されない (deep copy)。
+func TestRedactHeaders_Immutable(t *testing.T) {
+	values := []string{"Bearer one", "Bearer two"}
+	h := http.Header{"Authorization": values}
+
+	got := logger.RedactHeaders(h)
+
+	// 戻り値の値スライスを変更しても元は影響なし。
+	got["Authorization"][0] = "tampered"
+	if values[0] != "Bearer one" {
+		t.Errorf("RedactHeaders: source slice mutated by returned slice: got %v", values)
+	}
+
+	// 元の Header の値を変更しても戻り値は影響なし。
+	values[1] = "tampered-too"
+	if got["Authorization"][1] != logger.RedactedValue {
+		t.Errorf("RedactHeaders: returned slice changed when source mutated, got %v", got["Authorization"])
+	}
+}
+
+// 補助テスト: RedactMap の immutable 保証 — ネスト map / 配列も非破壊。
+func TestRedactMap_Immutable(t *testing.T) {
+	nested := map[string]any{"client_id": "public"}
+	arr := []any{map[string]any{"k": "v"}}
+	in := map[string]any{
+		"nested": nested,
+		"arr":    arr,
+	}
+	got := logger.RedactMap(in)
+
+	// 戻り値の nested を変更しても元は影響なし。
+	got["nested"].(map[string]any)["client_id"] = "tampered"
+	if nested["client_id"] != "public" {
+		t.Errorf("RedactMap: source nested map mutated by returned map: %v", nested)
+	}
+
+	// 戻り値の配列要素を変更しても元は影響なし。
+	got["arr"].([]any)[0].(map[string]any)["k"] = "tampered"
+	if arr[0].(map[string]any)["k"] != "v" {
+		t.Errorf("RedactMap: source array element mutated: %v", arr)
+	}
+}
+
+// 補助テスト: nil 入力安全性。
+func TestRedactHeaders_Nil(t *testing.T) {
+	if got := logger.RedactHeaders(nil); got != nil {
+		t.Errorf("RedactHeaders(nil) = %v, want nil", got)
+	}
+}
+
+func TestRedactMap_Nil(t *testing.T) {
+	if got := logger.RedactMap(nil); got != nil {
+		t.Errorf("RedactMap(nil) = %v, want nil", got)
+	}
+}
+
+// T-49: apperror.CodedError の details にシークレット (password) を入れた場合、
+// logger.RedactMap 経由で [REDACTED] に置換される (apperror ↔ logger の連携確認)。
+func TestRedactMap_AppErrorDetailsIntegration(t *testing.T) {
+	e := apperror.New("INVALID_PARAMETER", "x").WithDetails(map[string]any{
+		"password": "leaked",
+		"field":    "email",
+	})
+
+	redacted := logger.RedactMap(e.Details())
+
+	if redacted["password"] != logger.RedactedValue {
+		t.Errorf("password in CodedError.Details should be redacted by logger, got %v", redacted["password"])
+	}
+	if redacted["field"] != "email" {
+		t.Errorf("non-secret field should be preserved, got %v", redacted["field"])
+	}
+}
+
+// upper は ASCII 範囲で大文字化 (テスト用簡易実装)。
+func upper(s string) string {
+	b := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			c -= 32
+		}
+		b[i] = c
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary

M0.2 ログ・エラー基盤の P1 (logger + apperror パッケージ) を実装。後続の P2 (HTTP middleware + server 統合 / Issue #13) と P3 (契約テスト + context 更新 / Issue #14) のための土台。

- **`internal/apperror/`**: 内部 API エラー型 `CodedError` + F-7 基本形 JSON シリアライザ。immutable (deep-copy) で `WithDetails` / `Wrap` を提供。`ToResponse` / `WriteJSON` で middleware から利用予定。
- **`internal/logger/`**: `log/slog` ベースの構造化ログ。
  - `Logger` (D2 薄い独自 IF): `Info` / `Warn` / `Error` / `Debug`。`Error` は err を構造化 attr "error" として付与 (F-1 ログインジェクション対策)。
  - `New` は writer を `NewFallbackWriter` で自動ラップする。stdout 失敗時は stderr フォールバック + atomic drop counter を機能させる (Q9)。
  - `FormatFromEnv`: `CORE_LOG_FORMAT={"" | json | text}` (Q2)。
  - `ReplaceAttr` で `time` を UTC RFC3339Nano に正規化 (Q4)。プロセス全体の `time.Local` は不変。
  - `WithRequestID` / `WithEventID`: context 経由で `request_id` (F-3) / `event_id` (F-4) を自動付与。**必須付与の保証は middleware (Issue #13) の責務**で、logger は consumer 責務に限定 (理由はコード内 docstring 参照)。
  - `RedactHeaders` / `RedactMap`: deny-list 22 件 (ヘッダ 6 + フィールド 16) を case-insensitive 完全一致で `[REDACTED]` 置換。ネスト map / `[]any` を再帰走査。部分一致禁止 (Q8)。deny-list は非公開で外部から書き換え不可。
  - `FallbackWriter`: stdout 失敗時に stderr へフォールバック + atomic drop counter (Q9)。`io.Writer` 部分書き込み + error にも対応 (二重出力防止、`pn` クランプで panic 回避)。
- **テスト**: T-1..T-21 (logger 21 ケース) + T-47..T-52 + T-49 (apperror 7 ケース) + 補助テスト多数。`go test -race` クリーン、`go vet` クリーン。
- **依存追加**: `github.com/google/uuid` v1.6.0 を**先行追加** (現状 `indirect`)。本 PR では未使用だが、後続 P2 で middleware が `uuid.NewV7()` を使って `request_id` を発番する際に必要。先行追加することで P2 を「実装と承認」の 2 段階分離に保てる (UUID v4 の混入リスクをルール化済み)。

各ステップで Codex レビューを実施し、CRITICAL=0 / HIGH=0 / MEDIUM<3 のゲート通過を確認済み。PR 全体レビュー (CRITICAL=0/HIGH=0/MEDIUM=2/LOW=1) も Gate PASS、MEDIUM 2 件は本ブランチで修正反映済み。

Closes #12

## Test plan

- [x] `make -C core build` が pass する
- [x] `make -C core test` が pass する (logger / apperror 含む全パッケージ)
- [x] `make -C core lint` が pass する (`go vet ./...`)
- [x] UUID v4 (`uuid.New` / `uuid.NewRandom`) が混入していないことを `grep -rn 'uuid\.New[^V]' core/` で確認 (出力 0 件)
- [x] 既存 M0.1 の `log.Fatal*` 使用が増えていないことを `grep -rn 'log\.Fatal' core/` で確認 (cmd/core/main.go の既存 2 箇所のみ)
- [x] `/pr-codex-review {番号}` で Codex に PR 全体をレビューさせ、ゲート (CRITICAL=0 / HIGH=0 / MEDIUM<3) を通過する