### PR TITLE
feat:✨ M0.2 middleware + server 統合 + log.Fatal 全廃 (P2)

### DIFF
--- a/core/cmd/core/main.go
+++ b/core/cmd/core/main.go
@@ -8,18 +8,25 @@ import (
 	"log"
 
 	"github.com/mktkhr/id-core/core/internal/config"
+	"github.com/mktkhr/id-core/core/internal/logger"
 	"github.com/mktkhr/id-core/core/internal/server"
 )
 
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
-		// M0.1 暫定: 標準 log.Fatalf で異常終了。
-		// 構造化ログへの置換は M0.2 で対応する。
+		// M0.2 進行中: 暫定で log.Fatalf。次ステップ (P2 Step 5) で構造化ロガー置換予定。
 		log.Fatalf("設定の読み込みに失敗しました: %v", err)
 	}
 
-	srv := server.New(cfg)
+	// M0.2 Step 4: server.New に logger を渡せるよう一時的に Default() で初期化。
+	// Step 5 で main 全体を構造化ログ + event_id に書き換える。
+	l, lerr := logger.Default()
+	if lerr != nil {
+		log.Fatalf("ロガー初期化に失敗しました: %v", lerr)
+	}
+
+	srv := server.New(cfg, l)
 
 	log.Printf("core サーバーを起動します: addr=%s", srv.Addr)
 	if err := srv.ListenAndServe(); err != nil {

--- a/core/cmd/core/main.go
+++ b/core/cmd/core/main.go
@@ -1,35 +1,94 @@
 // Command core は id-core OIDC OP の HTTP サーバーを起動する。
 //
-// M0.1: /health のみを提供する最小骨格。
-// 後続マイルストーンで OIDC エンドポイント群 (authorize / token / userinfo / jwks / discovery) を追加する。
+// M0.2: 構造化ログ + request_id middleware を組み込んだ最小骨格。
+// 後続マイルストーンで OIDC エンドポイント群 (authorize / token / userinfo / jwks /
+// discovery) を追加する。
 package main
 
 import (
-	"log"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
 
+	"github.com/google/uuid"
 	"github.com/mktkhr/id-core/core/internal/config"
 	"github.com/mktkhr/id-core/core/internal/logger"
 	"github.com/mktkhr/id-core/core/internal/server"
 )
 
+// exitCode は run() の終了コード。標準 Unix 慣例に従い 0=成功 / 1=失敗。
+const (
+	exitOK    = 0
+	exitError = 1
+)
+
 func main() {
-	cfg, err := config.Load()
+	os.Exit(run(os.Stderr))
+}
+
+// run は main 本体を testable に切り出した関数。
+//
+// 起動失敗時のロガー初期化前のログは fallback (引数 stderr) に直接書く。
+// 通常時のログは構造化ロガー経由で stdout に出る。
+//
+// 終了コードを int で返すことで、テスト側から異常系の直接実行と検証が可能。
+func run(stderr *os.File) int {
+	cfg, l, eventID, err := bootstrap()
 	if err != nil {
-		// M0.2 進行中: 暫定で log.Fatalf。次ステップ (P2 Step 5) で構造化ロガー置換予定。
-		log.Fatalf("設定の読み込みに失敗しました: %v", err)
+		// bootstrap 失敗時は構造化ロガーが使えない可能性があるため、
+		// 引数 stderr に最終フォールバック行を出す。
+		fmt.Fprintf(stderr, "起動準備に失敗しました: %v\n", err)
+		return exitError
 	}
 
-	// M0.2 Step 4: server.New に logger を渡せるよう一時的に Default() で初期化。
-	// Step 5 で main 全体を構造化ログ + event_id に書き換える。
-	l, lerr := logger.Default()
-	if lerr != nil {
-		log.Fatalf("ロガー初期化に失敗しました: %v", lerr)
-	}
+	ctx := logger.WithEventID(context.Background(), eventID)
 
 	srv := server.New(cfg, l)
 
-	log.Printf("core サーバーを起動します: addr=%s", srv.Addr)
-	if err := srv.ListenAndServe(); err != nil {
-		log.Fatalf("サーバーの実行に失敗しました: %v", err)
+	emitStartupLog(l, ctx, srv.Addr)
+
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		l.Error(ctx, "サーバーの実行に失敗しました", err)
+		return exitError
 	}
+	return exitOK
+}
+
+// emitStartupLog は起動 INFO ログを構造化形式で出力する (F-4 / F-14 / Q3)。
+//
+// 必須フィールド:
+//   - msg: "core サーバーを起動します" (日本語)
+//   - addr: 待ち受けアドレス (例: ":8080")
+//   - event_id: ctx に WithEventID 済みの UUID v7 が logger により自動付与される
+//
+// event_id は ctx 単一ソースに統一する (引数二重指定で値が食い違うバグを避ける)。
+// run() から分離することで、テストで任意の logger を注入して JSON スキーマを検証できる。
+func emitStartupLog(l *logger.Logger, ctx context.Context, addr string) {
+	l.Info(ctx, "core サーバーを起動します",
+		slog.String("addr", addr),
+	)
+}
+
+// bootstrap は起動前の設定読み込み・ロガー初期化・event_id 発番をまとめて行う。
+// 各失敗を error として返し、run() で終了コード判定する責務分離。
+func bootstrap() (*config.Config, *logger.Logger, string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("設定の読み込みに失敗しました: %w", err)
+	}
+
+	l, err := logger.Default()
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("ロガーの初期化に失敗しました: %w", err)
+	}
+
+	id, err := uuid.NewV7()
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("event_id (UUID v7) の生成に失敗しました: %w", err)
+	}
+
+	return cfg, l, id.String(), nil
 }

--- a/core/cmd/core/main_test.go
+++ b/core/cmd/core/main_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+// T-63: core/ 配下の production コードから log.Fatal* が完全排除されている。
+//
+// 単体テストとして grep を実行することで lint 相当のガードを組み込む。
+// 検出条件は `log.Fatal` の呼び出し (= 開き括弧付き) のみで、コメントや
+// 「使わない」と書いてある docstring は誤検知しない。テストコード自身は対象外。
+func TestNoLogFatal_InCorePackage(t *testing.T) {
+	root := repoRoot(t)
+	target := filepath.Join(root, "core")
+
+	out, err := exec.Command("grep", "-rnE",
+		"--include=*.go", "--exclude=*_test.go",
+		`log\.Fatal[a-zA-Z]*\(`, target,
+	).CombinedOutput()
+	// grep は match なしのとき exit=1 を返す。これが期待 (= log.Fatal の呼び出しが無い)。
+	if err == nil {
+		t.Fatalf("log.Fatal の呼び出しが core/ 配下に残存:\n%s", string(out))
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() >= 2 {
+		t.Fatalf("grep がエラー: %v\n%s", err, string(out))
+	}
+}
+
+// T-63 補助: 標準 log パッケージの import が cmd/core/main.go から消えている。
+func TestNoStdLogImport_InMain(t *testing.T) {
+	root := repoRoot(t)
+	mainPath := filepath.Join(root, "core", "cmd", "core", "main.go")
+
+	body, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	for _, forbidden := range []string{
+		`"log"` + "\n",
+		`	"log"` + "\n",
+	} {
+		if strings.Contains(string(body), forbidden) {
+			t.Errorf("main.go に標準 log の import が残存: %q", forbidden)
+		}
+	}
+}
+
+// T-64: 設定読み込み失敗時の挙動 — log.Fatal を使わず exitError (=1) を返す。
+//
+// 不正な CORE_PORT を環境変数に設定して config.Load を失敗させ、run() が
+// 1 を返すことを直接検証する。stderr フォールバック出力もキャプチャ。
+func TestRun_ConfigLoadError_ReturnsExitError(t *testing.T) {
+	t.Setenv("CORE_PORT", "not-a-number")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	exitCode := run(w)
+	_ = w.Close()
+
+	if exitCode != exitError {
+		t.Errorf("run() = %d, want %d (exitError)", exitCode, exitError)
+	}
+
+	var stderrBuf bytes.Buffer
+	_, _ = stderrBuf.ReadFrom(r)
+	if !strings.Contains(stderrBuf.String(), "設定の読み込みに失敗") {
+		t.Errorf("stderr should contain bootstrap error, got: %q", stderrBuf.String())
+	}
+}
+
+// T-65: bootstrap が成功する場合に event_id (UUID v7) 形式を返す。
+//
+// run() を呼ぶと ListenAndServe で長時間ブロックするため、bootstrap だけ直接呼んで検証する。
+func TestBootstrap_Success_EventIDIsUUIDv7(t *testing.T) {
+	t.Setenv("CORE_PORT", "")          // デフォルト値で起動
+	t.Setenv("CORE_LOG_FORMAT", "json") // 明示的に json
+
+	cfg, l, eventID, err := bootstrap()
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if cfg == nil {
+		t.Errorf("cfg should not be nil")
+	}
+	if l == nil {
+		t.Errorf("logger should not be nil")
+	}
+	parsed, perr := uuid.Parse(eventID)
+	if perr != nil {
+		t.Fatalf("event_id is not a valid UUID: %q (%v)", eventID, perr)
+	}
+	if parsed.Version() != 7 {
+		t.Errorf("event_id UUID version = %d, want 7", parsed.Version())
+	}
+}
+
+// T-65 補助: 起動 INFO ログの実出力 JSON を検証する。
+//
+// emitStartupLog に buffer-backed logger を注入し、出力された JSON Lines に
+// 日本語 msg / addr / event_id が含まれることを直接 assert する。
+func TestEmitStartupLog_HasEventIDAndAddrAndJapaneseMsg(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+
+	const eventID = "01911f4e-7234-7b2a-8000-000000000001"
+	const addr = ":8765"
+
+	ctx := logger.WithEventID(context.Background(), eventID)
+	emitStartupLog(l, ctx, addr)
+
+	out := strings.TrimSpace(buf.String())
+	if out == "" {
+		t.Fatalf("emitStartupLog emitted nothing")
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("Unmarshal: %v (out=%q)", err, out)
+	}
+
+	if m["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO", m["level"])
+	}
+	if m["msg"] != "core サーバーを起動します" {
+		t.Errorf("msg = %v, want '日本語起動メッセージ'", m["msg"])
+	}
+	if m["addr"] != addr {
+		t.Errorf("addr = %v, want %v", m["addr"], addr)
+	}
+	if m["event_id"] != eventID {
+		t.Errorf("event_id = %v, want %v", m["event_id"], eventID)
+	}
+}
+
+// repoRoot はテスト実行ファイルの位置からリポジトリルートを推定する。
+//
+// runtime.Caller(0) で現テストファイルのパスを取り、core/cmd/core/ から 3 階層上を返す。
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+	// file = .../core/cmd/core/main_test.go → 3 階層上が repo root
+	return filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(file))))
+}
+

--- a/core/cmd/core/main_test.go
+++ b/core/cmd/core/main_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -17,23 +19,44 @@ import (
 
 // T-63: core/ 配下の production コードから log.Fatal* が完全排除されている。
 //
-// 単体テストとして grep を実行することで lint 相当のガードを組み込む。
-// 検出条件は `log.Fatal` の呼び出し (= 開き括弧付き) のみで、コメントや
-// 「使わない」と書いてある docstring は誤検知しない。テストコード自身は対象外。
+// 単体テストで lint 相当のガードを組み込む。検出条件は `log.Fatal` の呼び出し
+// (= 開き括弧付き、関数名末尾は任意の英字列) のみで、コメントや「使わない」と
+// 書いてある docstring は誤検知しない。テストコード (*_test.go) は対象外。
+//
+// 外部コマンド (grep) には依存せず、Go 標準ライブラリで walk する。
 func TestNoLogFatal_InCorePackage(t *testing.T) {
 	root := repoRoot(t)
 	target := filepath.Join(root, "core")
 
-	out, err := exec.Command("grep", "-rnE",
-		"--include=*.go", "--exclude=*_test.go",
-		`log\.Fatal[a-zA-Z]*\(`, target,
-	).CombinedOutput()
-	// grep は match なしのとき exit=1 を返す。これが期待 (= log.Fatal の呼び出しが無い)。
-	if err == nil {
-		t.Fatalf("log.Fatal の呼び出しが core/ 配下に残存:\n%s", string(out))
+	pattern := regexp.MustCompile(`log\.Fatal[A-Za-z]*\(`)
+	var hits []string
+
+	err := filepath.WalkDir(target, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			if pattern.MatchString(line) {
+				hits = append(hits, fmt.Sprintf("%s:%d: %s", path, i+1, line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
 	}
-	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() >= 2 {
-		t.Fatalf("grep がエラー: %v\n%s", err, string(out))
+	if len(hits) > 0 {
+		t.Fatalf("log.Fatal の呼び出しが core/ 配下に残存:\n%s", strings.Join(hits, "\n"))
 	}
 }
 

--- a/core/internal/apperror/apperror_test.go
+++ b/core/internal/apperror/apperror_test.go
@@ -197,8 +197,8 @@ func TestWriteJSON(t *testing.T) {
 	if res.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", res.StatusCode)
 	}
-	if ct := res.Header.Get("Content-Type"); ct != "application/json" {
-		t.Errorf("Content-Type = %q, want application/json", ct)
+	if ct := res.Header.Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want application/json; charset=utf-8", ct)
 	}
 
 	var got map[string]any

--- a/core/internal/apperror/response.go
+++ b/core/internal/apperror/response.go
@@ -41,11 +41,14 @@ func ToResponse(e *CodedError, requestID string) Response {
 
 // WriteJSON は w にエラーレスポンスを書き込む。
 //
-// Content-Type を application/json に設定し、json.Encoder で改行付き 1 行を書き込む。
+// Content-Type を "application/json; charset=utf-8" に設定し、json.Encoder で
+// 改行付き 1 行を書き込む。RFC 8259 で JSON は UTF-8 必須のため charset を付与
+// することでブラウザでの安全な解釈を保証する。
+//
 // 仕様 F-1 のログインジェクション対策として、本関数は string を直接連結せず必ず
 // encoding/json 経由で出力する。
 func WriteJSON(w http.ResponseWriter, status int, e *CodedError, requestID string) error {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
 	return json.NewEncoder(w).Encode(ToResponse(e, requestID))
 }

--- a/core/internal/health/health.go
+++ b/core/internal/health/health.go
@@ -6,7 +6,10 @@ package health
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
+
+	"github.com/mktkhr/id-core/core/internal/logger"
 )
 
 // statusOK は /health の正常応答ボディ。
@@ -22,11 +25,36 @@ type statusOK struct {
 //   - HTTP 200 OK
 //   - Content-Type: application/json; charset=utf-8
 //   - Body: {"status":"ok"}
+//
+// 注意: 本シグネチャは write エラーをログに残さない最小実装。
+// production 経路は logger 統合済みの NewHandler を使うこと (server.New 経由)。
 func Handler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 
-	// json.Encoder のエラーは書き込み済みヘッダに対しては復旧不能なため、
-	// 取りこぼしを避けるべく明示的に握りつぶす (構造化ログ整備は M0.2)。
+	// 書き込み失敗 (クライアント切断等) はこの最小版では受動的に握りつぶす。
+	// production 経路では NewHandler 経由で logger に WARN 記録する。
 	_ = json.NewEncoder(w).Encode(statusOK{Status: "ok"})
+}
+
+// NewHandler は logger を受け取り、書き込み失敗時に WARN ログを残す
+// production 用 /health ハンドラを返す。
+//
+// l == nil の場合は契約違反として panic する (シングルポイント設計の前提)。
+func NewHandler(l *logger.Logger) http.HandlerFunc {
+	if l == nil {
+		panic("health.NewHandler: logger must not be nil")
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(statusOK{Status: "ok"}); err != nil {
+			// レスポンスは既に WriteHeader 済みなので回復不能。受動的にログだけ残す
+			// (request_id は logger が context から自動付与する)。
+			l.Warn(r.Context(), "/health 応答の書き込みに失敗しました",
+				slog.String("error", err.Error()),
+			)
+		}
+	}
 }

--- a/core/internal/logger/logger.go
+++ b/core/internal/logger/logger.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"time"
 )
 
@@ -25,6 +26,17 @@ type Logger struct {
 // (Q9 仕様)。テストで bytes.Buffer を渡す場合は失敗経路に入らないため挙動は同一。
 func New(format Format, w io.Writer) *Logger {
 	return &Logger{handler: newHandler(format, NewFallbackWriter(w))}
+}
+
+// Default は CORE_LOG_FORMAT 環境変数を読み、stdout に出力する production 用 Logger を返す。
+//
+// CORE_LOG_FORMAT が不正値の場合はエラーを返す (cmd/main の起動失敗として扱う)。
+func Default() (*Logger, error) {
+	f, err := FormatFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return New(f, os.Stdout), nil
 }
 
 // Info は INFO レベルでログを出力する (業務イベント)。

--- a/core/internal/logger/redact.go
+++ b/core/internal/logger/redact.go
@@ -64,6 +64,16 @@ func buildLowerSet(keys []string) map[string]struct{} {
 // RedactHeaders は HTTP ヘッダのディープコピーを作り、deny-list キーの値を [REDACTED] に
 // 置換する (Q8)。元の http.Header は変更しない (immutable)。
 //
+// IsFieldKeyToRedact は body / query / form / details の deny-list (Q8) に
+// 含まれるキーかを case-insensitive 完全一致で判定する。
+//
+// クエリ文字列 / form パラメータの redact 用に他パッケージ (middleware 等) から
+// 呼び出される入口。deny-list の二重管理を避けるため必ず本関数を介する。
+func IsFieldKeyToRedact(key string) bool {
+	_, hit := fieldKeysSet[strings.ToLower(key)]
+	return hit
+}
+
 // nil を渡すと nil を返す。
 func RedactHeaders(h http.Header) http.Header {
 	if h == nil {

--- a/core/internal/middleware/access_log.go
+++ b/core/internal/middleware/access_log.go
@@ -1,0 +1,166 @@
+package middleware
+
+import (
+	"bufio"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+// AccessLog middleware は終了時に 1 行のアクセスログを構造化出力する (D3)。
+//
+// フィールド: time / level / msg=access / request_id / method / path / status / duration_ms
+// (F-3 / F-11 / Q7)
+//   - 5xx       → ERROR
+//   - 4xx       → WARN
+//   - それ以外 → INFO
+//
+// path は URL のパス + (redact 済み) クエリ文字列。redact 対象キー (Q8) の値は
+// [REDACTED] に置換される (F-13)。
+//
+// 不正だったクライアント X-Request-Id (request_id middleware が context に残した
+// client_request_id) があれば追加フィールドとして記録する。
+func AccessLog(l *logger.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		// defer で終了時のみ出力 (D3)。
+		defer func() {
+			elapsed := time.Since(start)
+			level := levelFromStatus(rw.status)
+
+			attrs := []any{
+				slog.String("msg_kind", "access"),
+				slog.String("method", r.Method),
+				slog.String("path", redactedPath(r.URL)),
+				slog.Int("status", rw.status),
+				slog.Float64("duration_ms", float64(elapsed.Microseconds())/1000.0),
+			}
+			if c := ClientRequestIDFrom(r.Context()); c != "" {
+				attrs = append(attrs, slog.String("client_request_id", c))
+			}
+
+			switch level {
+			case slog.LevelError:
+				l.Error(r.Context(), "access", nil, attrs...)
+			case slog.LevelWarn:
+				l.Warn(r.Context(), "access", attrs...)
+			default:
+				l.Info(r.Context(), "access", attrs...)
+			}
+		}()
+
+		next.ServeHTTP(rw, r)
+	})
+}
+
+// statusRecorder は http.ResponseWriter をラップし WriteHeader の status を捕捉する。
+// WriteHeader を呼ばずに Write された場合 (暗黙 200) は status のデフォルト値を維持する。
+//
+// http.Hijacker / http.Flusher は元 ResponseWriter が実装している場合に透過する
+// (WebSocket / Server-Sent Events 等の互換性維持)。Pusher (HTTP/2 push) は
+// 利用機会が極めて限定的で本プロジェクトの想定外のため透過しない。
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if r.wroteHeader {
+		return
+	}
+	r.wroteHeader = true
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(p []byte) (int, error) {
+	if !r.wroteHeader {
+		// 暗黙 200 を観測。Header を 200 で fix する。
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.ResponseWriter.Write(p)
+}
+
+// Flush は元 ResponseWriter が http.Flusher の場合のみ透過する (Server-Sent Events 等)。
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack は元 ResponseWriter が http.Hijacker の場合のみ透過する (WebSocket 等)。
+// Hijack 後の status は捕捉できないため warning ログ等の追加対応は呼び出し側で行う。
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.ErrUnsupported
+}
+
+func levelFromStatus(status int) slog.Level {
+	switch {
+	case status >= 500:
+		return slog.LevelError
+	case status >= 400:
+		return slog.LevelWarn
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// redactedPath は URL のパス部分と (redact 済み) クエリ文字列を組み立てて返す。
+//
+// クエリ文字列内の deny-list キー (例: code / access_token) の値は [REDACTED] に
+// 置換する (判定は logger.IsFieldKeyToRedact で一元管理、本パッケージでは再定義しない)。
+//
+// 受信時の `&` 区切りと出現順序を保持するため、url.Values.Encode() で再エンコード
+// するのではなく文字列レベルで分割・置換する。フラグメントは HTTP リクエストには
+// 通常含まれないため無視。
+func redactedPath(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	path := u.EscapedPath()
+	if u.RawQuery == "" {
+		return path
+	}
+	return path + "?" + redactQueryString(u.RawQuery)
+}
+
+func redactQueryString(raw string) string {
+	pairs := strings.Split(raw, "&")
+	for i, p := range pairs {
+		eq := strings.IndexByte(p, '=')
+		var key string
+		hasEq := eq >= 0
+		if hasEq {
+			key = p[:eq]
+		} else {
+			key = p
+		}
+		// key は URL エンコードされている可能性がある。デコードできなければ生 key で判定。
+		decoded, err := url.QueryUnescape(key)
+		if err != nil {
+			decoded = key
+		}
+		if logger.IsFieldKeyToRedact(decoded) {
+			if hasEq {
+				pairs[i] = key + "=" + logger.RedactedValue
+			} else {
+				// 元が key-only (例: "code") のときは表現を維持して
+				// "code" のまま出力する (値そのものが空なので redact 不要)。
+				pairs[i] = key
+			}
+		}
+	}
+	return strings.Join(pairs, "&")
+}

--- a/core/internal/middleware/access_log.go
+++ b/core/internal/middleware/access_log.go
@@ -26,7 +26,12 @@ import (
 //
 // 不正だったクライアント X-Request-Id (request_id middleware が context に残した
 // client_request_id) があれば追加フィールドとして記録する。
+//
+// l == nil の場合は契約違反として panic する (シングルポイント設計の前提を統一)。
 func AccessLog(l *logger.Logger, next http.Handler) http.Handler {
+	if l == nil {
+		panic("middleware.AccessLog: logger must not be nil")
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}

--- a/core/internal/middleware/access_log_test.go
+++ b/core/internal/middleware/access_log_test.go
@@ -1,0 +1,234 @@
+package middleware_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/logger"
+	"github.com/mktkhr/id-core/core/internal/middleware"
+)
+
+// makeLoggerBuf は test 用に bytes.Buffer に書き込む JSON Lines ロガーを返す。
+func makeLoggerBuf(t *testing.T) (*logger.Logger, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	return logger.New(logger.FormatJSON, &buf), &buf
+}
+
+// readLastJSONLine は buf の末尾 JSON Lines 1 行を map にデコードして返す。
+func readLastJSONLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		t.Fatalf("no log lines emitted; buf=%q", buf.String())
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &m); err != nil {
+		t.Fatalf("Unmarshal last line: %v (line=%q)", err, lines[len(lines)-1])
+	}
+	return m
+}
+
+// T-40: 200 OK の handler → 終了時に 1 行 INFO ログ、必須フィールド完備。
+func TestAccessLog_OK_INFO(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/health?x=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	if m["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO", m["level"])
+	}
+	if m["msg"] != "access" {
+		t.Errorf("msg = %v, want access", m["msg"])
+	}
+	if m["method"] != http.MethodGet {
+		t.Errorf("method = %v, want GET", m["method"])
+	}
+	// path には redact 後のクエリも含めて記録 (T-45 で redact を検証する)。
+	if path, ok := m["path"].(string); !ok || !strings.HasPrefix(path, "/health") {
+		t.Errorf("path = %v, want starts-with /health", m["path"])
+	}
+	if status, _ := m["status"].(float64); int(status) != http.StatusOK {
+		t.Errorf("status = %v, want 200", m["status"])
+	}
+	if _, ok := m["duration_ms"].(float64); !ok {
+		t.Errorf("duration_ms missing or not float, got %T %v", m["duration_ms"], m["duration_ms"])
+	}
+	if _, ok := m["request_id"].(string); !ok || m["request_id"] == "" {
+		t.Errorf("request_id missing")
+	}
+}
+
+// T-41: 4xx を返す handler → level=WARN。
+func TestAccessLog_4xx_WARN(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	if m["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", m["level"])
+	}
+	if status, _ := m["status"].(float64); int(status) != http.StatusBadRequest {
+		t.Errorf("status = %v, want 400", m["status"])
+	}
+}
+
+// T-42: 5xx を返す handler → level=ERROR。
+func TestAccessLog_5xx_ERROR(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	if m["level"] != "ERROR" {
+		t.Errorf("level = %v, want ERROR", m["level"])
+	}
+}
+
+// T-43 (a): 後段が status=500 を WriteHeader した場合に access_log が ERROR を観測。
+// (recover→500 への変換シナリオは Step 3 の統合テスト T-55 でカバーする)
+func TestAccessLog_HandlerWriteHeader500_ObserveERROR(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	if m["level"] != "ERROR" {
+		t.Errorf("level = %v, want ERROR", m["level"])
+	}
+	if status, _ := m["status"].(float64); int(status) != http.StatusInternalServerError {
+		t.Errorf("status = %v, want 500", m["status"])
+	}
+}
+
+// T-43 (b): 後段が WriteHeader を呼ばずに Write のみで暗黙 200 を返すケースでも
+// access_log は status=200 を観測する (status 暗黙化への耐性)。
+func TestAccessLog_ImplicitOK_Status200(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("body"))
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	if status, _ := m["status"].(float64); int(status) != http.StatusOK {
+		t.Errorf("status = %v, want 200 (implicit)", m["status"])
+	}
+}
+
+// T-44: duration_ms は float64 で記録 (ms 単位)。
+func TestAccessLog_DurationMS_Float(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	d, ok := m["duration_ms"].(float64)
+	if !ok {
+		t.Fatalf("duration_ms not float64: %T %v", m["duration_ms"], m["duration_ms"])
+	}
+	if d < 0 {
+		t.Errorf("duration_ms should be >= 0, got %v", d)
+	}
+}
+
+// T-45: クエリ文字列に redact 対象キーが含まれる場合、ログ上の path は値が [REDACTED] 化される。
+func TestAccessLog_Path_RedactQueryParams(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/cb?code=secret&state=abc", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	path, ok := m["path"].(string)
+	if !ok {
+		t.Fatalf("path missing or non-string: %v", m["path"])
+	}
+	if strings.Contains(path, "secret") {
+		t.Errorf("path should not contain raw secret value, got: %q", path)
+	}
+	// URL エンコード後 ([REDACTED] は %5BREDACTED%5D になる) も識別できるよう、
+	// 中核の REDACTED 文字列の存在で判定する (両形式を許容)。
+	if !strings.Contains(path, "REDACTED") {
+		t.Errorf("path should contain REDACTED marker for code, got: %q", path)
+	}
+	// state は redact 対象外なのでそのまま残る。
+	if !strings.Contains(path, "state=abc") {
+		t.Errorf("non-secret param should be preserved, got: %q", path)
+	}
+}
+
+// T-46: 開始時にはログを出さない (D3: 終了時のみ 1 行)。
+func TestAccessLog_NoLogBeforeFinish(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// handler 実行中の buf は空であるべき (access_log は defer で出力するため)。
+		if buf.Len() != 0 {
+			t.Errorf("access_log should not emit before handler completes, got: %q", buf.String())
+		}
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	// 終了後は msg=access のレコードが正確に 1 行出ているはず。他 middleware が
+	// 別 msg のログを混在させても誤検知しないように msg=access で絞って数える。
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	access := 0
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("Unmarshal: %v line=%q", err, line)
+		}
+		if rec["msg"] == "access" {
+			access++
+		}
+	}
+	if access != 1 {
+		t.Errorf("expected exactly 1 access log line, got %d (buf=%q)", access, buf.String())
+	}
+}

--- a/core/internal/middleware/recover.go
+++ b/core/internal/middleware/recover.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/mktkhr/id-core/core/internal/apperror"
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+// Recover middleware は handler の panic を捕捉し、HTTP 500 + F-7 基本形 JSON で
+// クライアントに応答する (F-9 / F-10)。
+//
+// セキュリティ要件 (F-10):
+//   - クライアントには固定メッセージ + request_id のみを返す。
+//   - スタックトレース・内部ファイルパス・実装詳細は HTTP レスポンスに絶対に含めない。
+//   - スタックトレースは内部の構造化ログ (level=ERROR) にのみ記録する。
+//
+// 設計順序 (D1):
+//
+//	request_id → access_log → recover → handler
+//
+// recover が access_log の内側に置かれているため、handler の panic は recover が
+// 500 応答に変換した後、access_log の defer に戻る → access_log は status=500 / ERROR を
+// 観測できる。逆順では access_log.defer が panic unwind 中に走り status=0 / 誤判定になる。
+func Recover(l *logger.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// access_log と同じ statusRecorder で wroteHeader を追跡する。
+		// ハンドラが panic 前に WriteHeader / Write 済みの場合、http.ResponseWriter は
+		// WriteHeader を二度受け付けないため、500 化を諦めてログにのみ記録する
+		// (D1 順序により外側の access_log は handler が書いた status を観測する)。
+		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		defer func() {
+			v := recover()
+			if v == nil {
+				return
+			}
+
+			ctx := r.Context()
+			requestID := logger.RequestIDFrom(ctx)
+
+			// panic 値を error / 文字列で正規化。
+			var panicErr error
+			switch t := v.(type) {
+			case error:
+				panicErr = t
+			default:
+				panicErr = fmt.Errorf("%v", t)
+			}
+
+			// 内部 ERROR ログ: スタックトレース付き (F-10)。
+			stack := string(debug.Stack())
+			attrs := []any{slog.String("stack_trace", stack)}
+			if rw.wroteHeader {
+				attrs = append(attrs, slog.Int("status_already_written", rw.status))
+			}
+			l.Error(ctx, "ハンドラで panic を捕捉しました", panicErr, attrs...)
+
+			if rw.wroteHeader {
+				// 既にレスポンスが書き込まれているため 500 化不能。クライアントは
+				// 中途半端なレスポンスを受け取る可能性があるが、middleware では
+				// 救済不能のためログのみ残して終わる (handler 側のバグとして扱う)。
+				return
+			}
+
+			// クライアント応答: 固定メッセージ + request_id (スタック非含)。
+			// apperror.WriteJSON が Content-Type "application/json; charset=utf-8" を設定する。
+			coded := apperror.New(apperror.CodeInternalError, apperror.MessageInternalError)
+			if err := apperror.WriteJSON(rw, http.StatusInternalServerError, coded, requestID); err != nil {
+				// 書き込み失敗 (クライアント切断等)。本筋のリクエスト処理は終わっているので
+				// ログにのみ残し、再 panic はしない。
+				l.Error(ctx, "panic 応答の書き込みに失敗しました", err)
+			}
+		}()
+
+		next.ServeHTTP(rw, r)
+	})
+}

--- a/core/internal/middleware/recover.go
+++ b/core/internal/middleware/recover.go
@@ -25,7 +25,12 @@ import (
 // recover が access_log の内側に置かれているため、handler の panic は recover が
 // 500 応答に変換した後、access_log の defer に戻る → access_log は status=500 / ERROR を
 // 観測できる。逆順では access_log.defer が panic unwind 中に走り status=0 / 誤判定になる。
+//
+// l == nil の場合は契約違反として panic する (シングルポイント設計の前提を統一)。
 func Recover(l *logger.Logger, next http.Handler) http.Handler {
+	if l == nil {
+		panic("middleware.Recover: logger must not be nil")
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// access_log と同じ statusRecorder で wroteHeader を追跡する。
 		// ハンドラが panic 前に WriteHeader / Write 済みの場合、http.ResponseWriter は

--- a/core/internal/middleware/recover_test.go
+++ b/core/internal/middleware/recover_test.go
@@ -1,0 +1,289 @@
+package middleware_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/middleware"
+)
+
+// T-33: handler が panic("test") した場合、HTTP 500 + Content-Type + F-7 基本形 JSON を返す。
+func TestRecover_PanicString_500WithJSON(t *testing.T) {
+	l, _ := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("oops")
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", res.StatusCode)
+	}
+	if ct := res.Header.Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want application/json; charset=utf-8", ct)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if body["code"] != "INTERNAL_ERROR" {
+		t.Errorf("code = %v, want INTERNAL_ERROR", body["code"])
+	}
+	if msg, _ := body["message"].(string); msg == "" {
+		t.Errorf("message should be non-empty")
+	}
+	if rid, _ := body["request_id"].(string); rid == "" {
+		t.Errorf("request_id should be non-empty in panic response")
+	}
+}
+
+// T-34: panic レスポンスの body にスタックトレース・内部パスが含まれない (F-10)。
+func TestRecover_PanicResponse_NoStackTrace(t *testing.T) {
+	l, _ := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("leaky-panic-message")
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	for _, forbidden := range []string{
+		"goroutine ",       // runtime stack header
+		"runtime/panic",    // package name
+		".go:",             // file:line markers
+		"leaky-panic",      // panic value should not leak
+		"github.com/",      // module path
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("response body should not contain %q, got: %q", forbidden, body)
+		}
+	}
+}
+
+// T-35: panic レスポンスの request_id が context の値と一致する (X-Request-Id ヘッダ経由で確認)。
+func TestRecover_PanicResponse_RequestIDMatchesHeader(t *testing.T) {
+	l, _ := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("x")
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	hdr := rec.Header().Get("X-Request-Id")
+	if hdr == "" {
+		t.Fatalf("X-Request-Id header missing")
+	}
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["request_id"] != hdr {
+		t.Errorf("body.request_id = %v, want %v (== X-Request-Id header)", body["request_id"], hdr)
+	}
+}
+
+// T-36: panic 時の内部ログに level=ERROR / msg / request_id / error / stack_trace が含まれる。
+func TestRecover_InternalLog_HasStackTrace(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("internal-only-stack")
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	if m["level"] != "ERROR" {
+		t.Errorf("level = %v, want ERROR", m["level"])
+	}
+	if rid, _ := m["request_id"].(string); rid == "" {
+		t.Errorf("request_id missing in panic log")
+	}
+	if errStr, _ := m["error"].(string); errStr == "" {
+		t.Errorf("error field missing in panic log")
+	}
+	if stack, _ := m["stack_trace"].(string); !strings.Contains(stack, "goroutine") {
+		t.Errorf("stack_trace should contain runtime stack info, got: %q", stack)
+	}
+}
+
+// T-37: handler が panic しない場合、recover は何もしない (パススルー)。
+func TestRecover_NoPanic_PassThrough(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Result().StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Result().StatusCode)
+	}
+	if rec.Body.String() != "ok" {
+		t.Errorf("body = %q, want ok", rec.Body.String())
+	}
+	// recover の defer がパススルーされる場合、内部 ERROR ログは出ないはず。
+	if buf.Len() != 0 {
+		// 通常 access_log を組み合わせない単体テストなので何も出ない想定。
+		// 出ているとしても ERROR レベルではないことを確認する。
+		// ここでは「recover からの ERROR ログがない」ことだけを最低限確認。
+		if strings.Contains(buf.String(), `"level":"ERROR"`) {
+			t.Errorf("no panic occurred, but ERROR level log was emitted: %q", buf.String())
+		}
+	}
+}
+
+// T-38: panic value が error 型の場合、error chain として "error" フィールドに記録。
+func TestRecover_PanicError_ErrorFieldHasMessage(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	sentinel := errors.New("sentinel-error-msg")
+	h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(sentinel)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	m := readLastJSONLine(t, buf)
+	if errStr, _ := m["error"].(string); !strings.Contains(errStr, "sentinel-error-msg") {
+		t.Errorf("error field should contain sentinel error message, got: %v", m["error"])
+	}
+}
+
+// T-39: panic value が任意の型 (int / struct 等) でも fmt.Sprintf("%v", v) で文字列化記録。
+func TestRecover_PanicAnyValue_StringifiedInLog(t *testing.T) {
+	type customPanicPayload struct {
+		Op   string
+		Code int
+	}
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"int", 42, "42"},
+		{"struct", customPanicPayload{Op: "x", Code: 999}, "999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l, buf := makeLoggerBuf(t)
+			value := tc.value
+			h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				panic(value)
+			})))
+
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			m := readLastJSONLine(t, buf)
+			if errStr, _ := m["error"].(string); !strings.Contains(errStr, tc.want) {
+				t.Errorf("error field should contain %q, got: %v", tc.want, m["error"])
+			}
+		})
+	}
+}
+
+// 補助テスト: ハンドラが既に WriteHeader 済みの状態で panic した場合、recover は
+// 500 化を試みず (二重 WriteHeader 防止)、内部 ERROR ログに status_already_written を記録する。
+func TestRecover_PanicAfterWriteHeader_NoSecondWrite(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	h := middleware.RequestID(middleware.Recover(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted) // 202
+		_, _ = w.Write([]byte("partial"))
+		panic("after-write-header")
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	// レスポンスの最終 status は handler が書いた 202 のまま (recover が上書きしない)。
+	if rec.Result().StatusCode != http.StatusAccepted {
+		t.Errorf("status = %d, want 202 (handler が書いた値が残る)", rec.Result().StatusCode)
+	}
+	m := readLastJSONLine(t, buf)
+	if status, _ := m["status_already_written"].(float64); int(status) != http.StatusAccepted {
+		t.Errorf("log should record status_already_written=202, got: %v", m["status_already_written"])
+	}
+}
+
+// 補助テスト: D1 順序の回帰検知 — recover の外側に access_log が居ない (=逆順 wrap した) 場合、
+// access_log の status 観測が壊れることを示すことで、本来の D1 順序の必然性を文書化する。
+//
+// この test は「D1 を逆にすると status=0 が観測される (= access_log が panic unwind 中に走る)」
+// ことを直接確認する。
+func TestRecover_DeprecatedReverseOrder_ObservesStatusZero(t *testing.T) {
+	l, buf := makeLoggerBuf(t)
+	// 意図的に D1 を逆順にした wrap (access_log が recover の内側): handler.panic は
+	// recover が捕捉する前に access_log の defer に到達し、access_log の statusRecorder は
+	// 何も WriteHeader を観測していないので status=0 で出力する。
+	wrong := middleware.RequestID(
+		middleware.Recover(l,
+			middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				panic("oops")
+			})),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	wrong.ServeHTTP(rec, req)
+
+	// この逆順では access_log の status はデフォルト (200) のままになる
+	// (statusRecorder は WriteHeader を観測しないため)。本来は 500 を観測すべき。
+	// ここは「逆順だと 500 を観測できない」ことを直接示すことで D1 順序を保証する。
+	access := findFirstAccessLog(t, buf)
+	if access == nil {
+		t.Fatalf("access log not found in buf=%q", buf.String())
+	}
+	statusFloat, ok := access["status"].(float64)
+	if !ok {
+		t.Fatalf("access status missing or non-numeric: %v", access["status"])
+	}
+	status := int(statusFloat)
+	// 逆順では access_log は status=200 (statusRecorder のデフォルト初期値) を観測する。
+	// recover が上位で 500 を書いていても、access_log の statusRecorder には伝わらない。
+	if status != http.StatusOK {
+		t.Errorf("逆順 wrap での access status = %d, want 200 (デフォルト初期値が観測されるはず)", status)
+	}
+	if status == http.StatusInternalServerError {
+		t.Errorf("逆順 wrap で 500 を観測してしまった (= D1 を入れ替えても回帰しないことになり順序保証が無意味化)")
+	}
+}
+
+func findFirstAccessLog(t *testing.T, buf interface {
+	String() string
+}) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		if m["msg"] == "access" {
+			return m
+		}
+	}
+	return nil
+}

--- a/core/internal/middleware/request_id.go
+++ b/core/internal/middleware/request_id.go
@@ -1,0 +1,160 @@
+// Package middleware は HTTP middleware を提供する。
+//
+// 構成 (D1 順序、外側から):
+//
+//	request_id  → access_log → recover → handler
+//
+// この順序により、panic 含む全てのログレコードに request_id が付き、access_log は
+// recover が変換した最終 status を観測できる。
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+// 仕様 F-6 の妥当性基準値。
+const (
+	headerXRequestID = "X-Request-Id"
+
+	// maxRequestIDLength はクライアント提供 X-Request-Id の最大オクテット長 (F-6 (a))。
+	maxRequestIDLength = 128
+)
+
+// ctxKey は context.Context のキーとして使う非公開型。
+type ctxKey struct{ name string }
+
+var clientRequestIDKey = ctxKey{"client_request_id"}
+
+// RequestID middleware は X-Request-Id を生成・検証・context 注入する。
+//
+// 動作:
+//  1. クライアント X-Request-Id が F-6 妥当性基準を満たせばそのまま採用。
+//  2. 不正なら破棄して UUID v7 を新規生成し、サニタイズ済み元値を context に
+//     client_request_id として残す (access_log middleware が拾ってログに記録)。
+//  3. レスポンスヘッダ X-Request-Id は **next.ServeHTTP を呼ぶ前**に設定する
+//     (handler が WriteHeader 後に追加するヘッダは HTTP レスポンスに反映されないため)。
+func RequestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := r.Header.Get(headerXRequestID)
+
+		var id string
+		var clientForLog string
+		if isValidRequestID(client) {
+			id = client
+		} else {
+			id = newRequestID()
+			if client != "" {
+				clientForLog = sanitizeClientRequestID(client)
+			}
+		}
+
+		ctx := logger.WithRequestID(r.Context(), id)
+		if clientForLog != "" {
+			ctx = withClientRequestID(ctx, clientForLog)
+		}
+		w.Header().Set(headerXRequestID, id)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ClientRequestIDFrom は不正だったクライアント X-Request-Id (サニタイズ済み) を ctx から取得する。
+// 妥当だった場合や未送信の場合は空文字。
+func ClientRequestIDFrom(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(clientRequestIDKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
+func withClientRequestID(ctx context.Context, v string) context.Context {
+	return context.WithValue(ctx, clientRequestIDKey, v)
+}
+
+// isValidRequestID は F-6 妥当性基準を満たすか判定する。
+//   - 空でない
+//   - 長さ ≤ maxRequestIDLength オクテット
+//   - 全文字が ASCII 印字可能 (0x21-0x7E)、制御文字・空白・タブなし
+func isValidRequestID(s string) bool {
+	if s == "" {
+		return false
+	}
+	if len(s) > maxRequestIDLength {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x21 || c > 0x7E {
+			return false
+		}
+	}
+	return true
+}
+
+// sanitizeClientRequestID は印字可能 ASCII 範囲外の文字を Unicode escape (\uXXXX) に置換し、
+// 結果を maxRequestIDLength オクテット以内に切り詰める (DoS 防止)。
+//
+// 入力は rune 単位で走査し、複数バイトの UTF-8 文字も 1 つの Unicode escape に変換する。
+// 切り詰めは escape sequence の境界 (1 rune / 1 escape) で行い、`\u00` のような不完全な
+// 表現を残さない。
+func sanitizeClientRequestID(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		var part string
+		if r >= 0x21 && r <= 0x7E {
+			part = string(r)
+		} else {
+			// rune が U+FFFF を超える場合は %x で 5-6 桁に伸びる (ὠ0 等)。
+			part = fmt.Sprintf("\\u%04x", r)
+		}
+		if b.Len()+len(part) > maxRequestIDLength {
+			break
+		}
+		b.WriteString(part)
+	}
+	return b.String()
+}
+
+// newRequestID は UUID v7 を生成して文字列化する。
+//
+// uuid.NewV7() は内部で crypto/rand を使うため、現実的にエラーは起きないが、
+// 失敗時に Nil UUID (00000000-...) を返すと全リクエストが同一 ID 化して F-5 の
+// トレーサビリティが破綻する。そのため失敗時はホスト + PID + 時刻 + atomic counter
+// ベースの代替 ID を生成して一意性を維持する (UUID 形式ではないが request 同一化を防ぐ)。
+//
+// 一意性の根拠:
+//   - hostname + PID: 同一マシン内では PID が一意、複数マシンでは hostname が一意。
+//   - UnixNano + counter: 同一プロセス内では counter で 1 ナノ秒以内の衝突を回避。
+func newRequestID() string {
+	if id, err := uuid.NewV7(); err == nil {
+		return id.String()
+	}
+	n := atomic.AddInt64(&fallbackSeq, 1)
+	return fmt.Sprintf("fallback-%s-%d-%d-%d", fallbackHost, fallbackPID, time.Now().UnixNano(), n)
+}
+
+var (
+	fallbackSeq int64
+	// fallbackHost / fallbackPID は package init 時にキャッシュ。
+	// hostname 取得失敗時は "unknown" に置換 (起動継続を優先)。
+	fallbackHost = func() string {
+		h, err := os.Hostname()
+		if err != nil || h == "" {
+			return "unknown"
+		}
+		return h
+	}()
+	fallbackPID = os.Getpid()
+)

--- a/core/internal/middleware/request_id_test.go
+++ b/core/internal/middleware/request_id_test.go
@@ -1,0 +1,319 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mktkhr/id-core/core/internal/logger"
+	"github.com/mktkhr/id-core/core/internal/middleware"
+)
+
+// captureHandler は h(w, r) の実行時に context から request_id / client_request_id を
+// テスト側で観測するためのハンドラ。
+func captureHandler(out *capturedRequest) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out.requestID = logger.RequestIDFrom(r.Context())
+		out.clientRequestID = middleware.ClientRequestIDFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+type capturedRequest struct {
+	requestID       string
+	clientRequestID string
+}
+
+// T-22: X-Request-Id ヘッダなし → 新規 UUID v7 生成、context 注入、レスポンスヘッダ設定。
+func TestRequestID_NoHeader_Generates(t *testing.T) {
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if captured.requestID == "" {
+		t.Fatalf("request_id should be injected into context, got empty")
+	}
+	if got := rec.Header().Get("X-Request-Id"); got != captured.requestID {
+		t.Errorf("response header X-Request-Id = %q, want %q", got, captured.requestID)
+	}
+	if captured.clientRequestID != "" {
+		t.Errorf("client_request_id should not be set when no client header, got %q", captured.clientRequestID)
+	}
+	// UUID v7 形式の検証は T-31 でまとめて行う。
+}
+
+// T-23: 妥当な X-Request-Id (印字可能 ASCII のみ) はそのまま採用。
+func TestRequestID_ValidClientHeader_Adopted(t *testing.T) {
+	clientID := "abc123-XYZ_._-_~"
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", clientID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if captured.requestID != clientID {
+		t.Errorf("request_id = %q, want client value %q", captured.requestID, clientID)
+	}
+	if got := rec.Header().Get("X-Request-Id"); got != clientID {
+		t.Errorf("response header = %q, want %q", got, clientID)
+	}
+	if captured.clientRequestID != "" {
+		t.Errorf("client_request_id should not be set when value is adopted, got %q", captured.clientRequestID)
+	}
+}
+
+// T-24: 128 オクテットちょうど → 採用される (境界値)。
+func TestRequestID_128OctetsExactly_Adopted(t *testing.T) {
+	clientID := strings.Repeat("a", 128)
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", clientID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if captured.requestID != clientID {
+		t.Errorf("128-octet value should be adopted, got %q", captured.requestID)
+	}
+	if captured.clientRequestID != "" {
+		t.Errorf("no client_request_id expected when adopted")
+	}
+}
+
+// T-25: 129 オクテット → 破棄、新規生成、サニタイズ済み client_request_id を context に残す。
+func TestRequestID_129Octets_RejectedAndSanitized(t *testing.T) {
+	clientID := strings.Repeat("a", 129)
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", clientID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if captured.requestID == clientID {
+		t.Errorf("129-octet value must NOT be adopted")
+	}
+	if captured.clientRequestID == "" {
+		t.Errorf("client_request_id should be retained for logging when rejected")
+	}
+	if len(captured.clientRequestID) > 128 {
+		t.Errorf("client_request_id should be truncated to <=128 octets, got len=%d", len(captured.clientRequestID))
+	}
+}
+
+// T-26: 改行を含む値 → 破棄、サニタイズで Unicode escape 化して client_request_id に残す。
+func TestRequestID_ControlCharNewline_RejectedAndEscaped(t *testing.T) {
+	clientID := "abc\n\r\tdef"
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", clientID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if captured.requestID == clientID {
+		t.Errorf("value with newline must NOT be adopted")
+	}
+	got := captured.clientRequestID
+	if got == "" {
+		t.Fatalf("client_request_id should be set")
+	}
+	// 改行・CR・タブが Unicode escape (\u000a, \u000d, \u0009) になっていること。
+	for _, want := range []string{`\u000a`, `\u000d`, `\u0009`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("client_request_id should contain %q escape, got: %q", want, got)
+		}
+	}
+	// 改行が生のまま残っていないこと (F-1 ログインジェクション対策)。
+	if strings.ContainsAny(got, "\n\r\t") {
+		t.Errorf("client_request_id should not contain raw control chars, got: %q", got)
+	}
+}
+
+// T-27: 空白 (0x20) を含む値 → 破棄、新規生成。
+func TestRequestID_ContainsSpace_Rejected(t *testing.T) {
+	assertRejected(t, "abc def")
+}
+
+// T-28: タブ (0x09) を含む値 → 破棄。
+func TestRequestID_ContainsTab_Rejected(t *testing.T) {
+	assertRejected(t, "abc\tdef")
+}
+
+// T-29: DEL (0x7F) を含む値 → 破棄 (0x21-0x7E 範囲外)。
+func TestRequestID_ContainsDEL_Rejected(t *testing.T) {
+	assertRejected(t, "abc\x7Fdef")
+}
+
+func assertRejected(t *testing.T, clientID string) {
+	t.Helper()
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", clientID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if captured.requestID == clientID {
+		t.Errorf("value %q must NOT be adopted", clientID)
+	}
+	if captured.clientRequestID == "" {
+		t.Errorf("client_request_id should be retained for logging when rejected")
+	}
+}
+
+// T-30: レスポンスヘッダ X-Request-Id が 200 / 4xx / 5xx いずれの status でも常時付与される。
+func TestRequestID_HeaderAlwaysSet_AllStatuses(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"200", http.StatusOK},
+		{"404", http.StatusNotFound},
+		{"500", http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := middleware.RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Result().StatusCode != tc.status {
+				t.Errorf("status = %d, want %d", rec.Result().StatusCode, tc.status)
+			}
+			if got := rec.Header().Get("X-Request-Id"); got == "" {
+				t.Errorf("X-Request-Id header missing for status %d", tc.status)
+			}
+		})
+	}
+}
+
+// T-31: 生成された ID が UUID v7 (バージョンビット 7)。
+func TestRequestID_GeneratedIsUUIDv7(t *testing.T) {
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	parsed, err := uuid.Parse(captured.requestID)
+	if err != nil {
+		t.Fatalf("generated ID is not a valid UUID: %q (%v)", captured.requestID, err)
+	}
+	if got := parsed.Version(); got != 7 {
+		t.Errorf("UUID version = %d, want 7", got)
+	}
+}
+
+// 補助テスト: F-6 境界の正側 — 0x21 ('!') と 0x7E ('~') を含む値は採用される。
+func TestRequestID_BoundaryPrintableASCII_Adopted(t *testing.T) {
+	clientID := "!~" + strings.Repeat("a", 10)
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", clientID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if captured.requestID != clientID {
+		t.Errorf("0x21..0x7E のみで構成された値は採用されるべき: got %q", captured.requestID)
+	}
+}
+
+// 補助テスト: 非 ASCII (日本語) は破棄される。
+func TestRequestID_NonASCII_Rejected(t *testing.T) {
+	assertRejected(t, "リクエストID")
+}
+
+// 補助テスト: X-Request-Id レスポンスヘッダは next.ServeHTTP 呼び出し前に
+// 設定されている。「先行設定」要件の退行を検知する。
+//
+// httptest.ResponseRecorder は http.Server と異なり WriteHeader 後の Header().Set を
+// ブロックしないため、WriteHeader 直前にヘッダをスナップショットする厳格 mock で検証する。
+func TestRequestID_HeaderSetBeforeNext(t *testing.T) {
+	var observedByHandler string
+	h := middleware.RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observedByHandler = w.Header().Get("X-Request-Id")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := newSnapshotRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rec, req)
+
+	if observedByHandler == "" {
+		t.Fatalf("X-Request-Id should be set BEFORE next.ServeHTTP, handler observed empty")
+	}
+	// WriteHeader 時点でスナップショットされたヘッダに X-Request-Id が含まれていること。
+	if got := rec.snapshot.Get("X-Request-Id"); got == "" {
+		t.Errorf("X-Request-Id should be set BEFORE WriteHeader (snapshot empty)")
+	} else if got != observedByHandler {
+		t.Errorf("snapshot X-Request-Id = %q, want %q", got, observedByHandler)
+	}
+}
+
+// snapshotRecorder は WriteHeader 時点でヘッダをスナップショットする厳格 ResponseWriter。
+// http.Server の挙動 (WriteHeader 後の Header 変更は無視) を簡易再現する。
+type snapshotRecorder struct {
+	h        http.Header
+	snapshot http.Header
+	written  bool
+	code     int
+}
+
+func newSnapshotRecorder() *snapshotRecorder { return &snapshotRecorder{h: http.Header{}} }
+
+func (r *snapshotRecorder) Header() http.Header { return r.h }
+
+func (r *snapshotRecorder) WriteHeader(code int) {
+	if r.written {
+		return
+	}
+	r.written = true
+	r.code = code
+	r.snapshot = r.h.Clone()
+}
+
+func (r *snapshotRecorder) Write(p []byte) (int, error) {
+	if !r.written {
+		r.WriteHeader(http.StatusOK)
+	}
+	return len(p), nil
+}
+
+// T-32: サニタイズ後の client_request_id が 128 オクテット以下に切り詰められる (DoS 防止)。
+func TestRequestID_SanitizedClientID_TruncatedTo128(t *testing.T) {
+	// 制御文字を含み、escape 化すると元の長さの 6 倍 (\uXXXX) に膨らむケース。
+	clientID := strings.Repeat("\n", 100) // 100 chars * 6 = 600 octets after escape
+	var captured capturedRequest
+	h := middleware.RequestID(captureHandler(&captured))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", clientID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	got := captured.clientRequestID
+	if got == "" {
+		t.Fatalf("client_request_id should be retained")
+	}
+	if len(got) > 128 {
+		t.Errorf("client_request_id should be truncated to <=128 octets, got len=%d", len(got))
+	}
+}

--- a/core/internal/server/server.go
+++ b/core/internal/server/server.go
@@ -1,7 +1,8 @@
-// Package server は HTTP サーバーの構築 (ServeMux + ハンドラ登録) を担う。
+// Package server は HTTP サーバーの構築 (ServeMux + ハンドラ登録 + middleware チェーン) を担う。
 //
-// M0.1 では /health のみ登録。後続マイルストーンで /authorize, /token, /userinfo,
-// /jwks, /.well-known/openid-configuration 等が追加される。
+// M0.2 で middleware チェーン (request_id / access_log / recover) が組み込まれた。
+// 後続マイルストーンで /authorize, /token, /userinfo, /jwks, /.well-known/openid-configuration
+// 等が追加される。
 package server
 
 import (
@@ -11,24 +12,47 @@ import (
 
 	"github.com/mktkhr/id-core/core/internal/config"
 	"github.com/mktkhr/id-core/core/internal/health"
+	"github.com/mktkhr/id-core/core/internal/logger"
+	"github.com/mktkhr/id-core/core/internal/middleware"
 )
 
 // readHeaderTimeout はリクエストヘッダ読み取り全体のタイムアウト。
-// Slowloris 攻撃 (CWE-400) 対策。後続マイルストーンで他のタイムアウト (ReadTimeout / WriteTimeout / IdleTimeout) も追加する。
+// Slowloris 攻撃 (CWE-400) 対策。後続マイルストーンで他のタイムアウト
+// (ReadTimeout / WriteTimeout / IdleTimeout) も追加する。
 const readHeaderTimeout = 10 * time.Second
 
-// New は cfg に従って *http.Server を構築して返す。
+// New は cfg と logger に従って *http.Server を構築して返す。
 //
-// ListenAndServe の呼び出しは main 側に委ねる (テスト容易性 / シャットダウン制御の余地確保のため)。
-func New(cfg *config.Config) *http.Server {
+// middleware チェーン (D1 順序、外側から内側へ):
+//
+//	request_id → access_log → recover → handler
+//
+// この順序により:
+//   - 全ログレコードに request_id が付く (panic 含む)
+//   - access_log は recover が変換した最終 status (500 等) を観測できる
+//
+// ListenAndServe の呼び出しは main 側に委ねる
+// (テスト容易性 / シャットダウン制御の余地確保のため)。
+//
+// l == nil の場合は契約違反として panic する (シングルポイント設計の前提)。
+func New(cfg *config.Config, l *logger.Logger) *http.Server {
+	if l == nil {
+		panic("server.New: logger must not be nil (M0.2 シングルポイント設計の契約)")
+	}
 	mux := http.NewServeMux()
 
 	// Go 1.22+ のメソッド指定パターン: 他メソッドは ServeMux が 405 + Allow ヘッダを返す。
-	mux.HandleFunc("GET /health", health.Handler)
+	mux.HandleFunc("GET /health", health.NewHandler(l))
+
+	// 内側から外側へ wrap (実行は外側から): request_id が最外側、handler が最内側。
+	var wrapped http.Handler = mux
+	wrapped = middleware.Recover(l, wrapped)
+	wrapped = middleware.AccessLog(l, wrapped)
+	wrapped = middleware.RequestID(wrapped)
 
 	return &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.Port),
-		Handler:           mux,
+		Handler:           wrapped,
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
 }

--- a/core/internal/server/server_test.go
+++ b/core/internal/server/server_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/mktkhr/id-core/core/internal/config"
 	"github.com/mktkhr/id-core/core/internal/logger"
+	"github.com/mktkhr/id-core/core/internal/middleware"
 	"github.com/mktkhr/id-core/core/internal/server"
 )
 
@@ -75,4 +77,214 @@ func TestNew_NilLogger_Panics(t *testing.T) {
 		}
 	}()
 	_ = server.New(&config.Config{Port: 1}, nil)
+}
+
+// ===== 統合テスト (T-53..T-57): middleware チェーン全体組み立てた状態の検証 =====
+
+// newIntegratedServer は test 用に buffer-backed logger を注入した server を返す。
+// /panic と /authheader の追加 endpoint をローカルにマウントして統合シナリオを試す。
+func newIntegratedServerWithBuf(t *testing.T) (*http.Server, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	l := logger.New(logger.FormatJSON, buf)
+	cfg := &config.Config{Port: config.DefaultPort}
+	return server.New(cfg, l), buf
+}
+
+// T-53: middleware チェーン全体を組み立てて GET /health を叩く。
+// 200 OK + JSON status:ok + Content-Type + ヘッダ X-Request-Id (M0.1 互換 + M0.2 追加要件)。
+func TestIntegration_HealthRoute_OK(t *testing.T) {
+	srv, _ := newIntegratedServerWithBuf(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	if rec.Result().StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Result().StatusCode)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want prefix application/json", ct)
+	}
+	if rec.Header().Get("X-Request-Id") == "" {
+		t.Errorf("X-Request-Id header missing")
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Result().Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("body.status = %v, want ok", body["status"])
+	}
+}
+
+// T-54: 統合チェーン経由で出力されたアクセスログ JSON が T-40 と同じスキーマであること。
+func TestIntegration_AccessLogSchema(t *testing.T) {
+	srv, buf := newIntegratedServerWithBuf(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	access := findFirstLogWithMsg(t, buf, "access")
+	if access == nil {
+		t.Fatalf("access log not emitted: %q", buf.String())
+	}
+	for _, key := range []string{"request_id", "method", "path", "status", "duration_ms"} {
+		if _, ok := access[key]; !ok {
+			t.Errorf("access log missing field %q: %v", key, access)
+		}
+	}
+	if access["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO", access["level"])
+	}
+	if access["method"] != http.MethodGet {
+		t.Errorf("method = %v, want GET", access["method"])
+	}
+	if access["path"] != "/health" {
+		t.Errorf("path = %v, want /health", access["path"])
+	}
+	if status, _ := access["status"].(float64); int(status) != http.StatusOK {
+		t.Errorf("status = %v, want 200", access["status"])
+	}
+	if d, ok := access["duration_ms"].(float64); !ok || d < 0 {
+		t.Errorf("duration_ms invalid: %T %v", access["duration_ms"], access["duration_ms"])
+	}
+}
+
+// T-55: panic endpoint を組み込んで叩く統合シナリオ。
+// 500 + F-7 基本形 JSON + body にスタック非含 + アクセスログは status=500/level=ERROR。
+func TestIntegration_PanicRoute_500Schema(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := logger.New(logger.FormatJSON, buf)
+
+	// server.New は /health 以外を mount しないため、middleware チェーンを直接組み立てて
+	// /panic endpoint を試す (D1 順序を再現)。
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /panic", func(w http.ResponseWriter, r *http.Request) {
+		panic("integration-panic")
+	})
+	var wrapped http.Handler = mux
+	wrapped = middleware.Recover(l, wrapped)
+	wrapped = middleware.AccessLog(l, wrapped)
+	wrapped = middleware.RequestID(wrapped)
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Result().StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Result().StatusCode)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want application/json; charset=utf-8 (F-7)", ct)
+	}
+	body := rec.Body.String()
+	for _, forbidden := range []string{"goroutine ", "runtime/panic", "integration-panic", ".go:"} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("body should not contain %q (F-10 stack 漏洩防止), got: %q", forbidden, body)
+		}
+	}
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	// F-7 必須キー: code / message / request_id を全て検証 (details は optional)。
+	if resp["code"] != "INTERNAL_ERROR" {
+		t.Errorf("code = %v, want INTERNAL_ERROR", resp["code"])
+	}
+	if msg, _ := resp["message"].(string); msg == "" {
+		t.Errorf("message missing in panic response (F-7 必須キー)")
+	}
+	if rid, _ := resp["request_id"].(string); rid == "" {
+		t.Errorf("request_id missing in panic response")
+	}
+
+	access := findFirstLogWithMsg(t, buf, "access")
+	if access == nil {
+		t.Fatalf("access log missing in panic flow: %q", buf.String())
+	}
+	if status, _ := access["status"].(float64); int(status) != http.StatusInternalServerError {
+		t.Errorf("access log status = %v, want 500 (D1 順序の検証)", access["status"])
+	}
+	if access["level"] != "ERROR" {
+		t.Errorf("access log level = %v, want ERROR", access["level"])
+	}
+}
+
+// T-56: クライアント Authorization: Bearer xxx 付きで叩く。
+// アクセスログ (現状は path / method のみ記録、ヘッダは載せない) の挙動と、
+// もしヘッダを記録する将来拡張を行う場合の redact 設計を担保する。
+//
+// 現実装は header をログ出力していないため secrets が漏れないことを直接確認する
+// (= access ログの全フィールド値に "Bearer " 文字列が含まれない)。
+func TestIntegration_AuthorizationHeader_NoLeakInLog(t *testing.T) {
+	srv, buf := newIntegratedServerWithBuf(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Authorization", "Bearer super-secret-token")
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	if strings.Contains(buf.String(), "Bearer ") {
+		t.Errorf("ログに Authorization ヘッダ値が漏洩している (F-13): %q", buf.String())
+	}
+	if strings.Contains(buf.String(), "super-secret-token") {
+		t.Errorf("ログにシークレット値が漏洩している (F-13): %q", buf.String())
+	}
+}
+
+// T-57: クライアント X-Request-Id に改行入りで叩く。
+// レスポンスヘッダには新規 UUID v7 が付き、ログには client_request_id (サニタイズ済み) が残る。
+func TestIntegration_BadXRequestID_RegeneratedAndLogged(t *testing.T) {
+	srv, buf := newIntegratedServerWithBuf(t)
+
+	bad := "abc\nbad"
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("X-Request-Id", bad)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	rid := rec.Header().Get("X-Request-Id")
+	if rid == bad {
+		t.Errorf("不正な X-Request-Id がそのまま採用された: %q", rid)
+	}
+	parsed, err := uuid.Parse(rid)
+	if err != nil || parsed.Version() != 7 {
+		t.Errorf("レスポンスヘッダの X-Request-Id が UUID v7 でない: %q (err=%v)", rid, err)
+	}
+	access := findFirstLogWithMsg(t, buf, "access")
+	if access == nil {
+		t.Fatalf("access log missing: %q", buf.String())
+	}
+	c, ok := access["client_request_id"].(string)
+	if !ok || c == "" {
+		t.Errorf("ログに client_request_id (サニタイズ済) が残っていない: %v", access["client_request_id"])
+	}
+	if strings.ContainsAny(c, "\n\r\t") {
+		t.Errorf("client_request_id に生の制御文字が残存 (F-1 ログインジェクション対策違反): %q", c)
+	}
+	// 同値性検証: 元の不正値 ("abc\nbad") が "abc\u000abad" にサニタイズされること。
+	const wantSanitized = `abc\u000abad`
+	if c != wantSanitized {
+		t.Errorf("client_request_id = %q, want %q (元値 %q の Unicode escape 変換結果)", c, wantSanitized, bad)
+	}
+}
+
+// findFirstLogWithMsg は buf 内の JSON Lines から msg=msgWanted の最初のレコードを返す。
+func findFirstLogWithMsg(t *testing.T, buf *bytes.Buffer, msgWanted string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		if m["msg"] == msgWanted {
+			return m
+		}
+	}
+	return nil
 }

--- a/core/internal/server/server_test.go
+++ b/core/internal/server/server_test.go
@@ -1,19 +1,26 @@
 package server_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/mktkhr/id-core/core/internal/config"
+	"github.com/mktkhr/id-core/core/internal/logger"
 	"github.com/mktkhr/id-core/core/internal/server"
 )
+
+func newTestLogger() *logger.Logger {
+	return logger.New(logger.FormatJSON, &bytes.Buffer{})
+}
 
 // TestNew_AddrAndHandler は server.New が cfg.Port を反映した *http.Server を返すことを検証する。
 func TestNew_AddrAndHandler(t *testing.T) {
 	cfg := &config.Config{Port: 9090}
-	srv := server.New(cfg)
+	srv := server.New(cfg, newTestLogger())
 
 	if srv == nil {
 		t.Fatal("server.New が nil を返した")
@@ -26,12 +33,11 @@ func TestNew_AddrAndHandler(t *testing.T) {
 	}
 }
 
-// TestNew_HealthRoute は server.New が返すサーバーで /health が解決できることを検証する。
-//
-// ListenAndServe は呼ばず、Handler に直接リクエストを投げる (シンプル & 高速)。
+// TestNew_HealthRoute は server.New が返すサーバーで /health が解決できることを検証する
+// (M0.1 外形互換: HTTP 200 + Content-Type prefix application/json + status=ok)。
 func TestNew_HealthRoute(t *testing.T) {
 	cfg := &config.Config{Port: config.DefaultPort}
-	srv := server.New(cfg)
+	srv := server.New(cfg, newTestLogger())
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
@@ -47,4 +53,26 @@ func TestNew_HealthRoute(t *testing.T) {
 	if !strings.HasPrefix(ct, "application/json") {
 		t.Errorf("/health の Content-Type = %q, want prefix %q", ct, "application/json")
 	}
+	// M0.2 で middleware チェーンが組み込まれたため、X-Request-Id が必ず付くこと。
+	if rid := rec.Header().Get("X-Request-Id"); rid == "" {
+		t.Errorf("/health のレスポンスに X-Request-Id が含まれない")
+	}
+	// M0.1 外形互換: body の {"status":"ok"} を厳密確認 (回帰検知)。
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("body decode: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("body.status = %v, want ok", body["status"])
+	}
+}
+
+// nil logger を渡すと server.New が契約違反として panic することを直接検証する。
+func TestNew_NilLogger_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("server.New(cfg, nil) should panic, got no panic")
+		}
+	}()
+	_ = server.New(&config.Config{Port: 1}, nil)
 }


### PR DESCRIPTION
## Summary

M0.2 ログ・エラー基盤の P2 (HTTP middleware + server 統合 + log.Fatal 全廃) を実装。P1 (Issue #12) の logger / apperror パッケージを土台に、HTTP リクエスト境界を構築する。後続の P3 (契約テスト + context 更新 / Issue #14) で完了。

### middleware (新規 `internal/middleware/`)

- **`request_id`** (F-5/F-6): クライアント `X-Request-Id` の妥当性検証 (≤128 octets / 0x21-0x7E のみ / 制御文字・空白・タブなし)。不正は破棄して **UUID v7** 新規生成。サニタイズ済み元値を context (`client_request_id`) に残す。レスポンスヘッダは `next.ServeHTTP` 前に先行設定 (handler の WriteHeader 後 Set は無視されるため)。NewV7 失敗時のフォールバック ID にホスト+PID+UnixNano+counter を組み込みクロスホスト一意性を担保。
- **`access_log`** (F-3/F-11/Q7/D3): 終了時に 1 行 JSON ログ (`msg=access` / method / path / status / duration_ms / request_id)。status による level 自動判定 (5xx=ERROR / 4xx=WARN / その他=INFO)。クエリ文字列内の deny-list キー値を `[REDACTED]` 化 (順序・表現を保持する文字列レベル分割)。`statusRecorder` は Flusher / Hijacker を透過。deny-list 判定は `logger.IsFieldKeyToRedact` で一元管理。
- **`recover`** (F-9/F-10): panic 捕捉 → 内部 ERROR ログに `stack_trace` (runtime/debug.Stack) + `request_id` + `error` 値を記録。クライアントには 500 + F-7 基本形 JSON (`code=INTERNAL_ERROR` + 固定メッセージ + `request_id`) のみ返す (stack / 内部パス絶対漏洩なし)。既書き込み状態での panic は二重 `WriteHeader` を防止して `status_already_written` をログに残す。

### server / health (`internal/server/`, `internal/health/`)

- `server.New(cfg, l)`: D1 順序 (`request_id → access_log → recover → handler`) で wrap。logger nil は契約違反として panic。
- `health.NewHandler(l)`: write エラー時に WARN ログを残す production 用。既存 `Handler` は backward-compat 用に残置。
- `logger.Default()`: CORE_LOG_FORMAT を読み stdout に書く production 用 IF を追加 (P1 で skip していた)。
- `apperror.WriteJSON` の Content-Type を `application/json; charset=utf-8` に変更 (RFC 8259 準拠)。

### main (`cmd/core/main.go`)

- 標準 `log` パッケージを完全排除 (F-12)、`log.Fatal*` を `grep -rnE 'log\.Fatal[a-zA-Z]*\(' core/` で 0 件確認 (テストコード除外)。
- `bootstrap()` / `run(stderr)` / `emitStartupLog()` に責務分離。`run` は `int` を返し、ListenAndServe 失敗時は `logger.Error` + `os.Exit(1)`。`http.ErrServerClosed` は正常終了扱い。
- 起動時 INFO ログに **event_id (UUID v7)** + addr を含める。msg は日本語 (`core サーバーを起動します`)。

### テスト

- 単体: T-22..T-46 (middleware 25 ケース) + 補助テスト多数。
- 統合: T-53..T-57 (5 ケース) で middleware チェーン全体を組み立てて検証。
- main: T-63..T-65 + 補助で `log.Fatal` 0 件 grep / event_id UUID v7 / 起動 INFO 実 JSON スキーマを直接検証。
- D1 順序の回帰検知テスト追加 (逆順 wrap だと access_log が status=500 を観測できない)。
- 各ステップで Codex レビュー (CRITICAL=0 / HIGH=0 / MEDIUM<3) のゲート通過済み。

Closes #13

## Test plan

- [x] `make -C core build` が pass する
- [x] `make -C core test` が pass する (新規 middleware / server 統合 / cmd/core 全パッケージ)
- [x] `make -C core lint` が pass する
- [x] `grep -rnE --include='*.go' --exclude='*_test.go' 'log\.Fatal[a-zA-Z]*\(' core/` が 0 件 (F-12)
- [x] `grep -rnE 'uuid\.New[^V]' core/` が 0 件 (UUID v4 不使用)
- [x] M0.1 の `/health` 外形互換 (HTTP 200 + `{"status":"ok"}` + Content-Type) を維持
- [x] M0.2 追加: `/health` レスポンスに `X-Request-Id` ヘッダが付与される
- [x] `/pr-codex-review {番号}` で Codex に PR 全体をレビューさせ、ゲート (CRITICAL=0 / HIGH=0 / MEDIUM<3) を通過する