### PR TITLE
fix:🐛 go.mod tidy: uuid を direct dependency に昇格

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -2,4 +2,4 @@ module github.com/mktkhr/id-core/core
 
 go 1.26.2
 
-require github.com/google/uuid v1.6.0 // indirect
+require github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

main マージ後の CI (`core/ go mod tidy check`) が連続失敗していた件を修正。

P1 (#12) で `github.com/google/uuid` を `// indirect` で先行追加していたが、P2 (#13) で middleware が `uuid.NewV7()` を直接利用するようになったため、go.mod 上は direct dependency に昇格すべき状態だった。`go mod tidy` 実行で `// indirect` コメントが落ちる差分が出るため、CI の tidy check が常時 fail していた。

実コードの挙動には影響なし (require 行の `// indirect` の有無のみ)。

## Test plan

- [x] `make -C core build && make -C core test && make -C core lint` 全件 pass
- [x] `go -C core mod tidy` を再実行しても差分なし (idempotent)
- [ ] CI の `go mod tidy check` が緑になる