### PR TITLE
feat:✨ M0.2 ログスキーマ契約テスト + Makefile lint + 規約書整備 (#14)

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -24,7 +24,7 @@ lint: ## go vet + プロジェクト固有禁止チェック (log.Fatal*)
 	@echo "==> go vet"
 	@go vet ./...
 	@echo "==> log.Fatal* check (project policy: forbidden in core/)"
-	@grep -rEn --include='*.go' --exclude='*_test.go' 'log\.Fatal[a-zA-Z]*\(' . ; rc=$$?; \
+	@grep -rEn --include='*.go' --exclude='*_test.go' '\blog\.Fatal[a-zA-Z]*\(' . ; rc=$$?; \
 	case $$rc in \
 		0) echo "ERROR: log.Fatal* is forbidden in core/. Use logger.Error + os.Exit(1) instead."; exit 1 ;; \
 		1) : ;; \

--- a/core/Makefile
+++ b/core/Makefile
@@ -20,8 +20,16 @@ test-cover: ## カバレッジ計測
 	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 	go tool cover -func=coverage.txt | tail -1
 
-lint: ## go vet によるリント (golangci-lint 導入は M0.2 以降)
-	go vet ./...
+lint: ## go vet + プロジェクト固有禁止チェック (log.Fatal*)
+	@echo "==> go vet"
+	@go vet ./...
+	@echo "==> log.Fatal* check (project policy: forbidden in core/)"
+	@grep -rEn --include='*.go' --exclude='*_test.go' 'log\.Fatal[a-zA-Z]*\(' . ; rc=$$?; \
+	case $$rc in \
+		0) echo "ERROR: log.Fatal* is forbidden in core/. Use logger.Error + os.Exit(1) instead."; exit 1 ;; \
+		1) : ;; \
+		*) echo "ERROR: grep exited with $$rc (unexpected)"; exit 1 ;; \
+	esac
 
 clean: ## ビルド成果物を削除
 	rm -rf $(BIN_DIR) coverage.txt

--- a/core/README.md
+++ b/core/README.md
@@ -7,29 +7,51 @@ id-core の OIDC OP (Identity Provider) 本体の Go 実装。
 - **Go**: `1.22+` (動作確認: `1.26.2`)
 - POSIX 準拠シェル + `make`
 
-## ディレクトリ構成 (M0.1 時点)
+## ディレクトリ構成 (M0.2 時点)
 
 ```
 core/
-├── cmd/core/main.go           # エントリポイント
+├── cmd/core/main.go           # エントリポイント (起動・signal handling)
 ├── internal/
 │   ├── config/                # 環境変数読み込み + バリデーション
-│   ├── server/                # *http.Server 構築 + ハンドラ登録
+│   ├── logger/                # 構造化ロガー (log/slog ラッパ + redact + fallback)
+│   ├── apperror/              # 構造化エラー型 + JSON シリアライザ
+│   ├── middleware/            # request_id / access_log / recover (D1 順序)
+│   ├── server/                # *http.Server 構築 + ハンドラ登録 + middleware チェーン
 │   └── health/                # /health エンドポイント
 ├── bin/                       # ビルド成果物 (.gitignore で除外)
 ├── go.mod
 └── Makefile
 ```
 
-後続マイルストーン (M0.2 ログ規約 / M0.3 DB / M1.x OIDC) でレイヤが拡張される。
+後続マイルストーン (M0.3 DB / M1.x OIDC) でレイヤが拡張される。
 
 ## 環境変数
 
-| Key         | 既定値 | 範囲              | 説明                          |
-| ----------- | ------ | ----------------- | ----------------------------- |
-| `CORE_PORT` | `8080` | `1〜65535` の整数 | HTTP サーバーのリッスンポート |
+| Key               | 既定値 | 範囲                 | 説明                                             |
+| ----------------- | ------ | -------------------- | ------------------------------------------------ |
+| `CORE_PORT`       | `8080` | `1〜65535` の整数    | HTTP サーバーのリッスンポート                    |
+| `CORE_LOG_FORMAT` | `json` | `json` または `text` | ログ出力フォーマット (本番=`json` / 開発=`text`) |
 
-未設定時は既定値で起動。不正値 (非数値・範囲外) の場合は明示エラーで起動失敗する。
+未設定時は既定値で起動。不正値 (非数値・範囲外、`CORE_LOG_FORMAT` の許容外値) の場合は明示エラーで起動失敗する。
+
+## ログ・エラー規約
+
+`core/` のログとエラーレスポンスは構造化規約に従う:
+
+- **ロガー**: `log/slog` ベース。`CORE_LOG_FORMAT=json` (既定) で JSON Lines、`text` で開発向け key=value
+- **時刻**: `time` フィールドは RFC3339Nano UTC (`Z` suffix 強制、`time.Local` への副作用なし)
+- **request_id**: 全 HTTP リクエストに UUID v7 で発番、レスポンスヘッダ `X-Request-Id` で返却
+- **event_id**: 起動・signal handler・ジョブ等の非 HTTP 経路に UUID v7 を付与
+- **エラーレスポンス**: `internal/apperror/` の基本形 `{ "code": "...", "message": "...", "details"?: {...}, "request_id": "..." }` (JSON、`code` は `SCREAMING_SNAKE_CASE`、`details` は任意)
+- **panic 時**: HTTP 500 + `{ "code": "INTERNAL_ERROR", "message": "...", "request_id": "..." }` のみ返し、スタックトレースは内部ログにのみ記録
+- **redact**: 認可・トークン・PII 系のキー (例: `password` / `access_token` / `Authorization` 等) はログ出力前に `[REDACTED]` 固定値へ置換
+
+詳細な規約は以下を参照:
+
+- ロギング・テレメトリ / エラーハンドリング / middleware 構成: [`docs/context/backend/conventions.md`](../docs/context/backend/conventions.md)
+- 実装パターン (middleware チェーン / context ID 付与 / redact): [`docs/context/backend/patterns.md`](../docs/context/backend/patterns.md)
+- パッケージ・環境変数・エラーコード: [`docs/context/backend/registry.md`](../docs/context/backend/registry.md)
 
 ## クイックスタート
 
@@ -73,7 +95,7 @@ Allow: GET, HEAD
 | `make run`        | ビルド + 起動                          |
 | `make test`       | ユニットテスト (`go test -race ./...`) |
 | `make test-cover` | カバレッジレポート生成                 |
-| `make lint`       | `go vet ./...`                         |
+| `make lint`       | `go vet ./...` + `log.Fatal*` 検査     |
 | `make clean`      | ビルド成果物を削除                     |
 
 ## エンドポイント (M0.1 時点)

--- a/core/internal/logger/contract_test.go
+++ b/core/internal/logger/contract_test.go
@@ -1,0 +1,306 @@
+// F-16 ログスキーマ契約テスト。
+//
+// 検証対象は 2 系統に分割する:
+//
+//	(a) HTTP 経路 (msg=access)        — time / level / msg / request_id / method / path / status / duration_ms
+//	(b) 非 HTTP 経路 (起動 / job 等)   — time / level / msg / event_id
+//
+// 方針:
+//   - 必須フィールドの存在 + 型 (string / number) を検証する。値の正確性は検証しない
+//     (本契約はスキーマ契約で、業務的妥当性は別テスト)。
+//   - 追加フィールドは許容する (前方互換)。
+//   - 必須フィールドの欠落・型変更はテスト失敗 (破壊的変更検知)。
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/logger"
+)
+
+type fieldKind int
+
+const (
+	kindString fieldKind = iota
+	kindNumber
+)
+
+func (k fieldKind) String() string {
+	switch k {
+	case kindString:
+		return "string"
+	case kindNumber:
+		return "number"
+	default:
+		return "unknown"
+	}
+}
+
+type fieldSpec struct {
+	name string
+	kind fieldKind
+}
+
+var httpRequiredFields = []fieldSpec{
+	{"time", kindString},
+	{"level", kindString},
+	{"msg", kindString},
+	{"request_id", kindString},
+	{"method", kindString},
+	{"path", kindString},
+	{"status", kindNumber},
+	{"duration_ms", kindNumber},
+}
+
+var nonHTTPRequiredFields = []fieldSpec{
+	{"time", kindString},
+	{"level", kindString},
+	{"msg", kindString},
+	{"event_id", kindString},
+}
+
+// validateContract は record が specs の必須フィールドを全て持ち、
+// 期待型と一致することを検証する。違反内容を文字列スライスで返す
+// (空 slice = 適合)。追加フィールドは無視 (許容)。
+func validateContract(record map[string]any, specs []fieldSpec) []string {
+	var problems []string
+	for _, s := range specs {
+		v, ok := record[s.name]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("missing field %q", s.name))
+			continue
+		}
+		switch s.kind {
+		case kindString:
+			if _, ok := v.(string); !ok {
+				problems = append(problems, fmt.Sprintf("field %q: expected %s, got %T", s.name, s.kind, v))
+			}
+		case kindNumber:
+			// encoding/json は数値を float64 にデコードする。
+			if _, ok := v.(float64); !ok {
+				problems = append(problems, fmt.Sprintf("field %q: expected %s, got %T", s.name, s.kind, v))
+			}
+		}
+	}
+	return problems
+}
+
+// emitHTTPAccessLog は access_log middleware と等価なフィールド構成で 1 行出力する。
+// access_log middleware の実装に依存せず logger 単体で検証可能にするため、契約テスト内で
+// 直接フィールドを組み立てる。
+func emitHTTPAccessLog(ctx context.Context, l *logger.Logger, extra ...any) {
+	args := []any{
+		"method", "GET",
+		"path", "/healthz",
+		"status", 200,
+		"duration_ms", 1.234,
+	}
+	args = append(args, extra...)
+	l.Info(ctx, "access", args...)
+}
+
+// emitStartupLog は cmd/main の起動ログと等価なフィールド構成で 1 行出力する。
+func emitStartupLog(ctx context.Context, l *logger.Logger, extra ...any) {
+	l.Info(ctx, "core starting", extra...)
+}
+
+func decodeOneLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	out := strings.TrimSpace(buf.String())
+	if strings.Count(out, "\n") != 0 {
+		t.Fatalf("expected single-line JSON, got newlines: %q", out)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("Unmarshal: %v (out=%q)", err, out)
+	}
+	return m
+}
+
+// T-58: HTTP 経路ログの必須フィールド存在 + 型を検証する。
+func TestContract_HTTPPathSchema(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+	ctx := logger.WithRequestID(context.Background(), "01890000-0000-7000-8000-000000000001")
+
+	emitHTTPAccessLog(ctx, l)
+
+	m := decodeOneLine(t, &buf)
+	if problems := validateContract(m, httpRequiredFields); len(problems) > 0 {
+		t.Fatalf("HTTP path schema violations:\n  %s\nrecord=%v", strings.Join(problems, "\n  "), m)
+	}
+}
+
+// T-59: 非 HTTP 経路ログの必須フィールド存在 + 型を検証する。
+func TestContract_NonHTTPPathSchema(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+	ctx := logger.WithEventID(context.Background(), "01890000-0000-7000-8000-000000000002")
+
+	emitStartupLog(ctx, l)
+
+	m := decodeOneLine(t, &buf)
+	if problems := validateContract(m, nonHTTPRequiredFields); len(problems) > 0 {
+		t.Fatalf("non-HTTP path schema violations:\n  %s\nrecord=%v", strings.Join(problems, "\n  "), m)
+	}
+}
+
+// T-60: 追加フィールドが含まれてもテストは失敗しない (前方互換)。
+func TestContract_FieldAdditionAllowed(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(logger.FormatJSON, &buf)
+	ctx := logger.WithRequestID(context.Background(), "01890000-0000-7000-8000-000000000003")
+
+	emitHTTPAccessLog(ctx, l,
+		"client_request_id", "external-trace-xyz",
+		"custom_extra", "tolerated",
+	)
+
+	m := decodeOneLine(t, &buf)
+	if problems := validateContract(m, httpRequiredFields); len(problems) > 0 {
+		t.Fatalf("extra fields should be tolerated, got violations:\n  %s\nrecord=%v",
+			strings.Join(problems, "\n  "), m)
+	}
+	if _, ok := m["custom_extra"]; !ok {
+		t.Errorf("custom_extra should be present in output, record=%v", m)
+	}
+}
+
+// T-61: 必須フィールドが欠けると validateContract が違反を返す (破壊的変更検知)。
+//
+// validateContract の検出能力自体を直接検証することで、T-58 / T-59 が
+// "実装が壊れた瞬間に契約テストが赤くなる" ことを保証する。
+func TestContract_FieldRemovalFails(t *testing.T) {
+	cases := []struct {
+		name      string
+		record    map[string]any
+		specs     []fieldSpec
+		wantField string
+	}{
+		{
+			name: "HTTP: request_id 欠落",
+			record: map[string]any{
+				"time":        "2026-05-02T00:00:00Z",
+				"level":       "INFO",
+				"msg":         "access",
+				"method":      "GET",
+				"path":        "/healthz",
+				"status":      float64(200),
+				"duration_ms": float64(1.0),
+			},
+			specs:     httpRequiredFields,
+			wantField: "request_id",
+		},
+		{
+			name: "HTTP: status 欠落",
+			record: map[string]any{
+				"time":        "2026-05-02T00:00:00Z",
+				"level":       "INFO",
+				"msg":         "access",
+				"request_id":  "id",
+				"method":      "GET",
+				"path":        "/healthz",
+				"duration_ms": float64(1.0),
+			},
+			specs:     httpRequiredFields,
+			wantField: "status",
+		},
+		{
+			name: "non-HTTP: event_id 欠落",
+			record: map[string]any{
+				"time":  "2026-05-02T00:00:00Z",
+				"level": "INFO",
+				"msg":   "core starting",
+			},
+			specs:     nonHTTPRequiredFields,
+			wantField: "event_id",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			problems := validateContract(tc.record, tc.specs)
+			if len(problems) == 0 {
+				t.Fatalf("expected violation for missing %q, got none", tc.wantField)
+			}
+			joined := strings.Join(problems, "\n")
+			if !strings.Contains(joined, fmt.Sprintf("missing field %q", tc.wantField)) {
+				t.Errorf("violation should mention missing %q, got:\n%s", tc.wantField, joined)
+			}
+		})
+	}
+}
+
+// T-62: フィールド型が変わると validateContract が違反を返す (破壊的変更検知)。
+func TestContract_FieldTypeChangeFails(t *testing.T) {
+	cases := []struct {
+		name      string
+		record    map[string]any
+		specs     []fieldSpec
+		wantField string
+	}{
+		{
+			name: "status が string にすり替わる",
+			record: map[string]any{
+				"time":        "2026-05-02T00:00:00Z",
+				"level":       "INFO",
+				"msg":         "access",
+				"request_id":  "id",
+				"method":      "GET",
+				"path":        "/healthz",
+				"status":      "200", // string にすり替え
+				"duration_ms": float64(1.0),
+			},
+			specs:     httpRequiredFields,
+			wantField: "status",
+		},
+		{
+			name: "duration_ms が string にすり替わる",
+			record: map[string]any{
+				"time":        "2026-05-02T00:00:00Z",
+				"level":       "INFO",
+				"msg":         "access",
+				"request_id":  "id",
+				"method":      "GET",
+				"path":        "/healthz",
+				"status":      float64(200),
+				"duration_ms": "1.0",
+			},
+			specs:     httpRequiredFields,
+			wantField: "duration_ms",
+		},
+		{
+			name: "request_id が number にすり替わる",
+			record: map[string]any{
+				"time":        "2026-05-02T00:00:00Z",
+				"level":       "INFO",
+				"msg":         "access",
+				"request_id":  float64(123),
+				"method":      "GET",
+				"path":        "/healthz",
+				"status":      float64(200),
+				"duration_ms": float64(1.0),
+			},
+			specs:     httpRequiredFields,
+			wantField: "request_id",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			problems := validateContract(tc.record, tc.specs)
+			if len(problems) == 0 {
+				t.Fatalf("expected violation for type-changed %q, got none", tc.wantField)
+			}
+			joined := strings.Join(problems, "\n")
+			if !strings.Contains(joined, fmt.Sprintf("field %q: expected", tc.wantField)) {
+				t.Errorf("violation should mention type mismatch on %q, got:\n%s", tc.wantField, joined)
+			}
+		})
+	}
+}

--- a/core/internal/logger/contract_test.go
+++ b/core/internal/logger/contract_test.go
@@ -17,10 +17,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/mktkhr/id-core/core/internal/logger"
+	"github.com/mktkhr/id-core/core/internal/middleware"
 )
 
 type fieldKind int
@@ -123,17 +126,46 @@ func decodeOneLine(t *testing.T, buf *bytes.Buffer) map[string]any {
 }
 
 // T-58: HTTP 経路ログの必須フィールド存在 + 型を検証する。
+//
+// 2 経路で検証する:
+//
+//   - "logger 直叩き": logger 単体で組み立てた access ログ
+//   - "middleware 実体": middleware.RequestID + middleware.AccessLog 経由の
+//     実 HTTP リクエストから出力されるログ (実装ドリフト検知)
 func TestContract_HTTPPathSchema(t *testing.T) {
-	var buf bytes.Buffer
-	l := logger.New(logger.FormatJSON, &buf)
-	ctx := logger.WithRequestID(context.Background(), "01890000-0000-7000-8000-000000000001")
+	t.Run("logger 直叩き", func(t *testing.T) {
+		var buf bytes.Buffer
+		l := logger.New(logger.FormatJSON, &buf)
+		ctx := logger.WithRequestID(context.Background(), "01890000-0000-7000-8000-000000000001")
 
-	emitHTTPAccessLog(ctx, l)
+		emitHTTPAccessLog(ctx, l)
 
-	m := decodeOneLine(t, &buf)
-	if problems := validateContract(m, httpRequiredFields); len(problems) > 0 {
-		t.Fatalf("HTTP path schema violations:\n  %s\nrecord=%v", strings.Join(problems, "\n  "), m)
-	}
+		m := decodeOneLine(t, &buf)
+		if problems := validateContract(m, httpRequiredFields); len(problems) > 0 {
+			t.Fatalf("HTTP path schema violations:\n  %s\nrecord=%v", strings.Join(problems, "\n  "), m)
+		}
+	})
+
+	t.Run("middleware 実体経由", func(t *testing.T) {
+		var buf bytes.Buffer
+		l := logger.New(logger.FormatJSON, &buf)
+
+		// middleware.RequestID + middleware.AccessLog の実体を通した出力を検証する。
+		// access_log middleware の出力スキーマが将来変わった場合、このテストが失敗する。
+		h := middleware.RequestID(middleware.AccessLog(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})))
+
+		req := httptest.NewRequest(http.MethodGet, "/health?x=1", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		// access_log は 1 行だけ出す。末尾改行を取り除いて単一レコードとして decode する。
+		m := decodeOneLine(t, &buf)
+		if problems := validateContract(m, httpRequiredFields); len(problems) > 0 {
+			t.Fatalf("HTTP path (middleware) schema violations:\n  %s\nrecord=%v", strings.Join(problems, "\n  "), m)
+		}
+	})
 }
 
 // T-59: 非 HTTP 経路ログの必須フィールド存在 + 型を検証する。

--- a/docs/context/backend/conventions.md
+++ b/docs/context/backend/conventions.md
@@ -1,6 +1,6 @@
 # バックエンド規約 (id-core / Go)
 
-> 最終更新: 2026-05-02 (M0.1: HTTP サーバー骨格 反映)
+> 最終更新: 2026-05-02 (M0.2: ログ・エラー・request_id の規約確定 反映)
 
 ## モジュール構成
 
@@ -25,23 +25,27 @@ core/
 
 `core/Makefile` は以下のターゲットを最低限提供する:
 
-| ターゲット   | 用途                                                  |
-| ------------ | ----------------------------------------------------- |
-| `help`       | ターゲット一覧を表示 (`make` または `make help`)      |
-| `build`      | バイナリをビルド (`go build -o bin/core ./cmd/core`)  |
-| `run`        | ビルド + 起動                                         |
-| `test`       | `go test -race ./...`                                 |
-| `test-cover` | カバレッジ計測 (`-coverprofile=coverage.txt`)         |
-| `lint`       | `go vet ./...` (M0.2 以降で `golangci-lint` 導入予定) |
-| `clean`      | `bin/` と `coverage.txt` を削除                       |
+| ターゲット   | 用途                                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `help`       | ターゲット一覧を表示 (`make` または `make help`)                                                                                                              |
+| `build`      | バイナリをビルド (`go build -o bin/core ./cmd/core`)                                                                                                          |
+| `run`        | ビルド + 起動                                                                                                                                                 |
+| `test`       | `go test -race ./...`                                                                                                                                         |
+| `test-cover` | カバレッジ計測 (`-coverprofile=coverage.txt`)                                                                                                                 |
+| `lint`       | `go vet ./...` + プロジェクト固有禁止チェック (`log.Fatal*` を非テスト `.go` ファイルに新規追加すると lint failure。`logger.Error` + `os.Exit(1)` を使うこと) |
+| `clean`      | `bin/` と `coverage.txt` を削除                                                                                                                               |
+
+`golangci-lint` の導入は後続マイルストーンで検討。
 
 ## 環境変数読み込みパターン
 
 - 環境変数は `internal/config/config.go` の `Load()` で集約読み込み
 - バリデーションエラーは `error` で返す (`log.Fatal` を直接呼ばない → テスト容易性確保)
-- `cmd/<binary>/main.go` で `error` を受けて `log.Fatalf` で異常終了
-- 命名: `CORE_<NAME>` プレフィックス (例: `CORE_PORT`)
+- `cmd/<binary>/main.go` で `error` を受けて `logger.Error` + `os.Exit(1)` で異常終了 (`log.Fatal*` の使用は禁止 / Makefile lint で検査)
+- 命名: `CORE_<NAME>` プレフィックス (例: `CORE_PORT`, `CORE_LOG_FORMAT`)
 - 範囲制約があるものは `MinXxx` / `MaxXxx` 定数として `config` パッケージで宣言
+
+環境変数の一覧は `docs/context/backend/registry.md` の「環境変数一覧」を参照。
 
 ## DB / マイグレーション
 
@@ -61,15 +65,151 @@ TBD — `/authorize`, `/token`, `/userinfo`, `/jwks.json`, `/.well-known/openid-
 
 TBD — 内部ユーザー管理・アカウントリンク・電話番号認証・SNS 認証 (LINE 等) のエンドポイント規約
 
-## エラーコード
+## エラーハンドリング
 
-TBD (M0.2 で確定)
+エラー型と JSON シリアライズは `core/internal/apperror/` パッケージで一元管理する (M0.2 で導入)。
+
+### 基本形 (F-7)
+
+内部 API のエラーレスポンスは下記の JSON 形式で返却する:
+
+```json
+{
+  "code": "INVALID_PARAMETER",
+  "message": "ポートは 1〜65535 の整数で指定してください",
+  "details": { "field": "CORE_PORT", "received": "0" },
+  "request_id": "01890000-0000-7000-8000-000000000000"
+}
+```
+
+| フィールド   | 型     | 必須 | 内容                                                                                                               |
+| ------------ | ------ | ---- | ------------------------------------------------------------------------------------------------------------------ |
+| `code`       | string | 必須 | `SCREAMING_SNAKE_CASE` のエラーコード (例: `INVALID_PARAMETER` / `INTERNAL_ERROR`)                                 |
+| `message`    | string | 必須 | 人間可読の本文 (M0.2〜M5.x スコープでは日本語、OIDC エンドポイント側は RFC 6749 準拠の英語フレーズ等を別途検討)    |
+| `details`    | object | 任意 | 補足情報 (object のみ。配列が必要なら object のキー配下にネスト)。シークレットを含めない (redact deny-list と整合) |
+| `request_id` | string | 必須 | リクエストの request_id (HTTP 経路) または起動 / ジョブの event_id (非 HTTP 経路)                                  |
+
+### エラーコード命名規則
+
+- `SCREAMING_SNAKE_CASE` で表記する
+- ドメイン語彙とエラー種別を組み合わせる (例: `ACCOUNT_NOT_FOUND` / `OTP_EXPIRED`)
+- panic 等の予期しないエラーには固定値 `INTERNAL_ERROR` を返す (F-9 / F-10)
+- OIDC エンドポイント (M1.x 以降) は RFC 6749 / 6750 / OpenID Connect Core が定める標準コード (`invalid_request` / `invalid_grant` / `invalid_token` 等) を併用する。本規約の `SCREAMING_SNAKE_CASE` は内部 API スコープに適用し、OIDC 標準エンドポイントは仕様準拠を優先する
+
+### details の制約
+
+- 型は object に限定 (`apperror.WithDetails(map[string]any)`)。配列を含めたい場合は object のキー配下にネストする
+- シークレットを含めない。redact deny-list (後述) と同一の命名規約に従い、deny-list 該当キーを `details` に詰めない
+- `details` を含めたエラーは内部 API のクライアント側 (フロントエンド) でフィールド単位の誘導 UI に活用する
+
+### redact 対象キー一覧 (Q8 完全一覧)
+
+ログ・エラーレスポンス出力前に値を `[REDACTED]` (固定値) に置換する。照合は **case-insensitive かつ完全一致**、ネスト object / 配列を再帰走査する。
+
+- ヘッダ (6 件): `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`
+- フィールド (16 件): `password`, `current_password`, `new_password`, `access_token`, `refresh_token`, `id_token`, `code`, `code_verifier`, `client_secret`, `assertion`, `client_assertion`, `private_key`, `secret`, `api_key`, `jwt`, `bearer_token`
+
+実装は `core/internal/logger/redact.go` に集約。クエリ文字列・form パラメータ・ログ attribute・`details` の出力経路で同一の deny-list を再利用する (二重管理禁止)。部分一致は誤検知防止のため禁止。
+
+### panic 時の挙動 (F-9 / F-10)
+
+- middleware の `recover` が panic を捕捉 → 5xx + `{ "code": "INTERNAL_ERROR", "message": "...", "request_id": "..." }` を返却
+- スタックトレースは内部ログ (ERROR レベル) にのみ記録し、レスポンス本文には含めない (情報漏えい対策)
+- スタック取得には `runtime.Stack` を使用し、長さ上限を設ける
+
+## ロギング・テレメトリ
+
+`core/internal/logger/` で構造化ログを一元提供する (M0.2 で導入)。
+
+### 実装スタック
+
+- ロガー: Go 標準 `log/slog` を薄くラップ (`core/internal/logger/Logger`)
+- フォーマット切替: `CORE_LOG_FORMAT=json|text` 環境変数 (既定 `json`、開発時は `text`、不正値は起動失敗)
+- 一意 ID 生成: UUID v7 (`github.com/google/uuid` v1.6+ の `uuid.NewV7`)。`uuid.New` / `uuid.NewRandom` (v4) は禁止
+- 出力先: 本番は標準出力 (1 行 1 レコードの JSON Lines)、テストは `bytes.Buffer`
+
+### `time` フィールド
+
+- 値は **RFC3339Nano UTC** (例: `2026-05-02T01:23:45.678901234Z`、`Z` suffix 強制)
+- `slog.HandlerOptions.ReplaceAttr` フックで UTC + `RFC3339Nano` に変換する
+- `time.Local = time.UTC` のようなプロセスグローバルな副作用は禁止 (他パッケージ・他テストへの汚染回避)
+
+### ログレベル使い分け (Q7)
+
+| レベル  | 用途                                                                      |
+| ------- | ------------------------------------------------------------------------- |
+| `DEBUG` | 本番では出力しない (フィルタ運用)。開発調査時のみ                         |
+| `INFO`  | 業務イベント・正常系の処理経過 (ログイン成功、リソース作成、起動・終了等) |
+| `WARN`  | クライアント起因の異常 (4xx)、復旧可能な障害、構成警告                    |
+| `ERROR` | サーバ起因の異常 (5xx)、panic、永続化失敗等の運用調査が必要な事象         |
+
+### 必須フィールド
+
+#### HTTP 経路 (access_log / handler ログ)
+
+| フィールド    | 型     | 必須 | 内容                                                                      |
+| ------------- | ------ | ---- | ------------------------------------------------------------------------- |
+| `time`        | string | 必須 | RFC3339Nano UTC                                                           |
+| `level`       | string | 必須 | `DEBUG` / `INFO` / `WARN` / `ERROR`                                       |
+| `msg`         | string | 必須 | ログメッセージ (`access` 等の固定 kind を別 attribute で明示する場合あり) |
+| `request_id`  | string | 必須 | UUID v7 (X-Request-Id 由来 or サーバ生成)                                 |
+| `method`      | string | 必須 | HTTP メソッド                                                             |
+| `path`        | string | 必須 | URL パス + (redact 済み) クエリ文字列                                     |
+| `status`      | number | 必須 | HTTP ステータスコード                                                     |
+| `duration_ms` | number | 必須 | 処理時間 (ミリ秒、float)                                                  |
+
+#### 非 HTTP 経路 (起動 / signal handler / ジョブ等)
+
+| フィールド | 型     | 必須 | 内容                                |
+| ---------- | ------ | ---- | ----------------------------------- |
+| `time`     | string | 必須 | RFC3339Nano UTC                     |
+| `level`    | string | 必須 | `DEBUG` / `INFO` / `WARN` / `ERROR` |
+| `msg`      | string | 必須 | ログメッセージ                      |
+| `event_id` | string | 必須 | UUID v7 (起動毎・ジョブ毎の一意 ID) |
+
+追加フィールドは許容 (前方互換)。フィールド削除・型変更は **`core/internal/logger/contract_test.go` の F-16 契約テストで失敗** する破壊的変更扱い。
+
+### `request_id` / `event_id` の伝播 (F-3 / F-4)
+
+- `logger.WithRequestID(ctx, id)` / `logger.RequestIDFrom(ctx)` で HTTP 経路に付与
+- `logger.WithEventID(ctx, id)` / `logger.EventIDFrom(ctx)` で非 HTTP 経路に付与
+- HTTP 経路の必須付与は `request_id` middleware (D1 順序の最外層) が担保する
+- 非 HTTP 経路の必須付与は `cmd/<binary>/main.go` 起動時とジョブランナー側で担保する
+- Domain 層 (将来導入) は context から取り出すのみ、ロガー直呼び出しは禁止 (F-14)
+
+### ログ出力失敗時の挙動 (Q9)
+
+- primary writer (stdout) 失敗時に **stderr にフォールバック**
+- stderr も失敗した場合は **atomic drop counter** を増分してリクエスト処理を継続 (リクエストを止めない)
+- `core/internal/logger/FallbackWriter.DropCount()` で counter を取得 (M1.x のメトリクス連携で公開予定)
+
+### ログメッセージ言語
+
+- 内部 API スコープでは `msg` / `error` フィールドを **日本語**で記述する
+- ただしフィールド名 (`request_id` / `status` 等) は英語の予約語を使用する
+- OIDC 標準エンドポイント (M1.x 以降) は OAuth 2.0 / OIDC 仕様の `error` / `error_description` 規約に従う
+
+### ログインジェクション対策 (F-1)
+
+- ロガーは `slog` の構造化 attribute (key/value) のみを公開し、文字列連結による出力は許容しない
+- `Error(ctx, msg, err, args...)` は `err.Error()` を構造化 attribute として渡し、改行・制御文字を JSON エンコーダ経由で安全にエスケープする
+
+## middleware 構成
+
+HTTP middleware の実行順序 (D1) を以下に統一する:
+
+```
+request_id  →  access_log  →  recover  →  handler
+```
+
+| middleware   | 責務                                                                                                                                                                         |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `request_id` | クライアント `X-Request-Id` の検証 + 不正なら UUID v7 を新規発番。サニタイズ済みの不正値は `client_request_id` として context に残す。レスポンスヘッダ `X-Request-Id` を設定 |
+| `access_log` | 終了時に 1 行のアクセスログを構造化出力 (5xx=ERROR / 4xx=WARN / それ以外=INFO)。`recover` が変換した最終 status を観測する                                                   |
+| `recover`    | panic を捕捉して 5xx + `INTERNAL_ERROR` を返す。スタックトレースを ERROR レベルでログ出力                                                                                    |
+
+D1 順序の根拠: 全ログレコード (panic 含む) に `request_id` を付与するため、`request_id` を最外層に置く。`access_log` を `recover` より外側に置くことで、`recover` 後の最終 status (5xx) を access ログに反映する。
 
 ## 認可
 
 TBD — id-core 自身の管理 API の認可方式 (CLAUDE.md 方針: IAM ミドルウェア不採用、手書きポリシー)
-
-## ロギング・テレメトリ
-
-M0.1 暫定: 標準 `log` パッケージで `Printf` / `Fatalf` を使用。
-M0.2 で `log/slog` ベースの構造化ログ + `request_id` ミドルウェアに置換する (`backend-logging` スキル参照)。

--- a/docs/context/backend/conventions.md
+++ b/docs/context/backend/conventions.md
@@ -113,7 +113,7 @@ TBD — 内部ユーザー管理・アカウントリンク・電話番号認証
 
 ### panic 時の挙動 (F-9 / F-10)
 
-- middleware の `recover` が panic を捕捉 → 5xx + `{ "code": "INTERNAL_ERROR", "message": "...", "request_id": "..." }` を返却
+- middleware の `recover` が panic を捕捉 → HTTP 500 + `{ "code": "INTERNAL_ERROR", "message": "...", "request_id": "..." }` を返却
 - スタックトレースは内部ログ (ERROR レベル) にのみ記録し、レスポンス本文には含めない (情報漏えい対策)
 - スタック取得には `runtime.Stack` を使用し、長さ上限を設ける
 

--- a/docs/context/backend/patterns.md
+++ b/docs/context/backend/patterns.md
@@ -1,6 +1,6 @@
 # バックエンド実装パターン (id-core / Go)
 
-> 最終更新: 2026-05-02 (M0.1 反映)
+> 最終更新: 2026-05-02 (M0.2: ログ・エラー・middleware パターン反映)
 
 ## アーキテクチャパターン
 
@@ -13,13 +13,13 @@ M1.x の OIDC エンドポイント実装着手時に **Package by Feature + ク
 
 ```go
 mux := http.NewServeMux()
-mux.HandleFunc("GET /health", health.Handler)
+mux.HandleFunc("GET /health", health.NewHandler(l).ServeHTTP)
 // 他メソッドは自動で 405 + Allow: GET, HEAD
 ```
 
 ## 設定読み込み + main 分離パターン
 
-`config` 層は `error` を返し、`main` で `log.Fatalf` する責務分担。テスト容易性を担保する。
+`config` 層は `error` を返し、`main` で `logger.Error` + `os.Exit(1)` する責務分担。テスト容易性を担保し、`log.Fatal*` は使用しない (Makefile の lint で検査)。
 
 ```go
 // internal/config/config.go
@@ -29,25 +29,148 @@ func Load() (*Config, error) {
 
 // cmd/core/main.go
 func main() {
+    ctx := logger.WithEventID(context.Background(), newEventID())
+    l, err := logger.Default()
+    if err != nil {
+        // logger 初期化前の起動失敗は stderr に直書きする (logger が無い)。
+        fmt.Fprintf(os.Stderr, "logger 初期化失敗: %v\n", err)
+        os.Exit(1)
+    }
     cfg, err := config.Load()
     if err != nil {
-        log.Fatalf("設定の読み込みに失敗しました: %v", err)
+        l.Error(ctx, "設定の読み込みに失敗しました", err)
+        os.Exit(1)
     }
-    srv := server.New(cfg)
+    srv := server.New(cfg, l)
     if err := srv.ListenAndServe(); err != nil {
-        log.Fatalf("サーバーの実行に失敗しました: %v", err)
+        l.Error(ctx, "サーバーの実行に失敗しました", err)
+        os.Exit(1)
     }
 }
 ```
 
+## middleware チェーンパターン (D1 順序)
+
+外側から `request_id` → `access_log` → `recover` → `handler` の順に wrap する。`server.New` が組み立てを集約し、`cmd/main` 側はチェーン構築を意識しない。
+
+```go
+// internal/server/server.go (抜粋)
+func New(cfg *config.Config, l *logger.Logger) *http.Server {
+    mux := http.NewServeMux()
+    mux.HandleFunc("GET /health", health.NewHandler(l).ServeHTTP)
+
+    // 内側から外側へ順に wrap (実行順は外側から内側)。
+    handler := middleware.Recover(l, mux)
+    handler = middleware.AccessLog(l, handler)
+    handler = middleware.RequestID(handler)
+
+    return &http.Server{Addr: cfg.Addr(), Handler: handler}
+}
+```
+
+D1 順序の根拠は `docs/context/backend/conventions.md` の「middleware 構成」節を参照。
+
+## context への ID 付与パターン
+
+`logger` パッケージが提供する `WithRequestID` / `WithEventID` で派生 context を作り、後段に渡す。Domain 層は context から取り出すのみ (ロガーへの直呼び出しは禁止 / F-14)。
+
+```go
+// HTTP 経路: middleware が WithRequestID 済み ctx を handler に渡す。
+func handler(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+    id := logger.RequestIDFrom(ctx) // middleware が必ず設定済み (空文字を防御的に許容)
+    _ = id
+}
+
+// 非 HTTP 経路: 起動・ジョブが WithEventID 済み ctx を後段に渡す。
+func startup() {
+    ctx := logger.WithEventID(context.Background(), newEventID())
+    bootstrap(ctx)
+}
+
+// Domain 層 (将来導入): context から取り出すのみ、ロガー直呼び出し禁止。
+func (s *AccountService) Create(ctx context.Context, ...) error {
+    // ログ出力は presentation / application 層に集約する。
+    return s.repo.Insert(ctx, ...)
+}
+```
+
+## redact パターン (deny-list)
+
+ログ出力前に redact deny-list (Q8 完全一覧) のキーを `[REDACTED]` 固定値へ置換する。実装は `core/internal/logger/redact.go` に集約し、二重管理を禁止する。
+
+```go
+// internal/logger/redact.go (抜粋)
+const RedactedValue = "[REDACTED]"
+
+// case-insensitive かつ完全一致でキーを判定 (部分一致は誤検知防止のため禁止)。
+func IsFieldKeyToRedact(key string) bool { /* ... */ }
+
+// http.Header / map[string]any を再帰走査して deny-list キーを置換した *コピー* を返す。
+// 元のオブジェクトは変更しない (immutable)。
+func RedactHeaders(h http.Header) http.Header { /* ... */ }
+func RedactMap(m map[string]any) map[string]any { /* ... */ }
+```
+
+クエリ文字列・form パラメータ等の deny-list 適用面は `IsFieldKeyToRedact` を呼び出して deny-list を再利用する (例: `middleware/access_log.go` の `redactQueryString`)。
+
+## エラーハンドリング
+
+`core/internal/apperror/` パッケージで `CodedError` を生成し、`apperror.WriteJSON` で HTTP レスポンスにシリアライズする (M0.2 で導入。M0.1 暫定の `fmt.Errorf` + `%w` のみのパターンを置き換える)。
+
+```go
+// 生成
+err := apperror.
+    New("INVALID_PARAMETER", "ポートは 1〜65535 の整数で指定してください").
+    WithDetails(map[string]any{"field": "CORE_PORT", "received": "0"}).
+    Wrap(cause) // 元エラーを error chain として保持 (errors.Is / errors.As 対応)
+
+// 内部ログ用文字列化 (公開しない)
+log.Error(ctx, "validation failed", err)
+
+// HTTP レスポンスへの書き出し (presentation 層)
+apperror.WriteJSON(w, http.StatusBadRequest, err, requestID)
+```
+
+panic 時は `recover` middleware が `INTERNAL_ERROR` 固定コードを書き出す (`apperror.CodeInternalError`)。
+
+## ログ出力失敗時のフォールバックパターン
+
+primary writer (stdout 等) の書き込み失敗時に stderr にフォールバックし、それも失敗したら atomic drop counter を増分する。`Logger.log` の呼び出し元にはエラーを返さない (リクエスト処理を止めない / Q9)。
+
+```go
+// internal/logger/fallback.go (抜粋)
+type FallbackWriter struct {
+    primary  io.Writer
+    fallback io.Writer
+    drops    atomic.Int64
+}
+
+func (w *FallbackWriter) Write(p []byte) (int, error) {
+    pn, perr := w.primary.Write(p)
+    if perr == nil {
+        return pn, nil
+    }
+    // 部分書き込み: primary が pn バイト書いた後にエラー → 残りを fallback に。
+    fn, ferr := w.fallback.Write(p[pn:])
+    if ferr == nil && fn == len(p)-pn {
+        return pn + fn, nil
+    }
+    w.drops.Add(1)
+    return len(p), nil // bytes 数は呼び出し側ループ条件のため正の値を返す
+}
+
+func (w *FallbackWriter) DropCount() int64 { return w.drops.Load() }
+```
+
 ## httptest ベースのハンドラテストパターン
 
-ServeMux ごと組み立てて `mux.ServeHTTP(rec, req)` を呼ぶ。これによりルーティング (405 / Allow) も検証できる。
+ServeMux ごと組み立てて `mux.ServeHTTP(rec, req)` を呼ぶ。これによりルーティング (405 / Allow) も検証できる。middleware を含めた検証が必要な場合は `server.New` で組み立てた handler 全体を `httptest.NewServer` で起動する。
 
 ```go
 func TestHandler_GET_Success(t *testing.T) {
     mux := http.NewServeMux()
-    mux.HandleFunc("GET /health", health.Handler)
+    mux.HandleFunc("GET /health", health.NewHandler(testLogger(t)).ServeHTTP)
 
     req := httptest.NewRequest(http.MethodGet, "/health", nil)
     rec := httptest.NewRecorder()
@@ -96,11 +219,7 @@ TBD (M4.3 / M5.3 で確定)
 
 TBD (M5.x で確定)
 
-## エラーハンドリング
-
-M0.1 暫定: `fmt.Errorf` で原因を `%w` ラップ。M0.2 で `apperror` パッケージを導入予定。
-
 ## DI / 依存注入
 
-M0.1 では `server.New(cfg)` にコンストラクタで設定を渡すだけ。
+M0.2 では `server.New(cfg, l)` にコンストラクタで設定 + ロガーを渡す。
 M1.x で UseCase / Repository を導入する際にコンストラクタ DI を `internal/server/router.go` に集約する。

--- a/docs/context/backend/registry.md
+++ b/docs/context/backend/registry.md
@@ -1,19 +1,22 @@
 # バックエンドレジストリ (id-core / Go)
 
-> 最終更新: 2026-05-02 (M0.1 反映)
+> 最終更新: 2026-05-02 (M0.2: ログ・エラー・middleware 反映)
 
 ## パッケージマッピング
 
-| パス                   | 用途                                  | 依存                                             |
-| ---------------------- | ------------------------------------- | ------------------------------------------------ |
-| `core/cmd/core`        | 実行ファイルエントリポイント (`main`) | `internal/config`, `internal/server`, `log`      |
-| `core/internal/config` | 環境変数読み込み + バリデーション     | `os`, `strconv`, `fmt`                           |
-| `core/internal/server` | `*http.Server` 構築 + ハンドラ登録    | `internal/config`, `internal/health`, `net/http` |
-| `core/internal/health` | `/health` ハンドラ                    | `encoding/json`, `net/http`                      |
+| パス                       | 用途                                                                                      | 依存                                                                                        |
+| -------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `core/cmd/core`            | 実行ファイルエントリポイント (`main`)。起動・signal handling・最終 ID 発番・logger 初期化 | `internal/config`, `internal/logger`, `internal/server`, `os`, `os/signal`, `context`       |
+| `core/internal/config`     | 環境変数読み込み + バリデーション                                                         | `os`, `strconv`, `fmt`                                                                      |
+| `core/internal/logger`     | 構造化ロガー (slog ラッパ + Format / Context / Redact / FallbackWriter)                   | `log/slog`, `github.com/google/uuid`, `context`, `io`, `sync/atomic`                        |
+| `core/internal/apperror`   | 構造化エラー型 (`CodedError`) + JSON シリアライザ (`Response` / `WriteJSON`)              | `encoding/json`, `errors`, `fmt`, `net/http`                                                |
+| `core/internal/middleware` | request_id / access_log / recover (D1 順序の HTTP middleware 群)                          | `internal/logger`, `internal/apperror`, `github.com/google/uuid`, `net/http`, `sync/atomic` |
+| `core/internal/server`     | `*http.Server` 構築 + ハンドラ登録 + middleware チェーン組み込み                          | `internal/config`, `internal/health`, `internal/logger`, `internal/middleware`, `net/http`  |
+| `core/internal/health`     | `/health` ハンドラ (logger 受け取りに対応)                                                | `encoding/json`, `internal/logger`, `net/http`                                              |
 
 ## Feature ディレクトリマッピング
 
-M0.1 では feature パッケージなし (機能横断的な骨格のみ)。
+M0.2 では feature パッケージなし (機能横断的な骨格 + ログ・エラー基盤のみ)。
 M1.x の OIDC 実装で `core/internal/features/<feature>/` が登場する。
 
 ## テーブル一覧
@@ -50,13 +53,24 @@ TBD
 
 ## 環境変数一覧
 
-| Key         | 既定値 | 範囲              | 必須 | 説明                               |
-| ----------- | ------ | ----------------- | ---- | ---------------------------------- |
-| `CORE_PORT` | `8080` | `1〜65535` の整数 | 任意 | core HTTP サーバーのリッスンポート |
+| Key               | 既定値 | 範囲                 | 必須 | 説明                                                               |
+| ----------------- | ------ | -------------------- | ---- | ------------------------------------------------------------------ |
+| `CORE_PORT`       | `8080` | `1〜65535` の整数    | 任意 | core HTTP サーバーのリッスンポート                                 |
+| `CORE_LOG_FORMAT` | `json` | `json` または `text` | 任意 | ログ出力フォーマット (本番=`json` / 開発=`text`)。不正値で起動失敗 |
 
 ## エラーコード一覧
 
-TBD (M0.2 で確定)
+### 共通 (内部 API)
+
+| code             | HTTP status | 用途                                                                        | 追加マイルストーン |
+| ---------------- | ----------- | --------------------------------------------------------------------------- | ------------------ |
+| `INTERNAL_ERROR` | 500         | panic 等の予期しないエラー (`recover` middleware が固定で返す / F-9 / F-10) | M0.2               |
+
+### OIDC 標準エンドポイント
+
+OIDC 標準エンドポイント (M1.x 以降) は RFC 6749 / 6750 / OpenID Connect Core が定める標準コード (`invalid_request` / `invalid_grant` / `invalid_token` / `invalid_client` 等) を採用する。本レジストリの `SCREAMING_SNAKE_CASE` は内部 API スコープに適用し、OIDC 標準コードは仕様準拠を優先する。
+
+詳細な命名規則 / `details` 制約 / panic 時の挙動は `docs/context/backend/conventions.md` の「エラーハンドリング」節を参照。
 
 ## マイグレーション一覧
 

--- a/docs/context/testing/backend.md
+++ b/docs/context/testing/backend.md
@@ -1,11 +1,80 @@
 # バックエンドテスト規約
 
-> 最終更新: 2026-04-25 (骨格セットアップ時点、内容 TBD)
-> このファイルは実装が始まった段階で記述する。
+> 最終更新: 2026-05-02 (M0.2: id-core / Go のテスト規約最低限を反映)
 
 ## id-core (Go) のテスト
 
-TBD — テストパターン・モック方針・カバレッジ基準。
+### 標準パターン
+
+- パッケージレイアウト: 外部テストパッケージ (`<pkg>_test`) を基本とし、内部 API を検証する場合のみ内部テスト (`<pkg>` 同名) を併用する
+- テストランナ: `go test -race ./...` (`make test`)。カバレッジは `make test-cover`
+- HTTP ハンドラ: `httptest.NewRequest` + `mux.ServeHTTP(rec, req)` で組み立てる (M0.1 から踏襲)。middleware を含めた検証は `server.New` の handler 全体を `httptest.NewServer` で起動する
+- 並列化: `t.Parallel()` を基本にする。ただし `t.Setenv` を使うテストは Go の仕様で `t.Parallel` と**併用不可**のため直列実行する
+- 環境変数の解除は `t.Setenv("KEY", "")` で空文字を設定し、Load 側で空文字をデフォルト扱いにする (Unsetenv 不可)
+
+### テーブル駆動テスト
+
+deny-list 系 (redact) や境界値検証は **テーブル駆動テスト**を用いる。
+
+```go
+func TestIsFieldKeyToRedact(t *testing.T) {
+    cases := []struct {
+        key  string
+        want bool
+    }{
+        {"password", true},
+        {"PASSWORD", true},      // case-insensitive
+        {"my_password", false},  // 部分一致は対象外
+        {"client_secret", true},
+    }
+    for _, tc := range cases {
+        t.Run(tc.key, func(t *testing.T) {
+            if got := logger.IsFieldKeyToRedact(tc.key); got != tc.want {
+                t.Errorf("IsFieldKeyToRedact(%q) = %v, want %v", tc.key, got, tc.want)
+            }
+        })
+    }
+}
+```
+
+### ログ buffer での検証パターン
+
+ロガーの出力を検証する場合は `bytes.Buffer` を `logger.New` の writer に渡し、JSON Lines を 1 行ずつ `json.Unmarshal` で `map[string]any` にデコードしてフィールド存在 + 型を検証する。`encoding/json` は数値を `float64` にデコードする点に注意。
+
+```go
+var buf bytes.Buffer
+l := logger.New(logger.FormatJSON, &buf)
+ctx := logger.WithRequestID(context.Background(), "test-id")
+l.Info(ctx, "access", "method", "GET", "path", "/", "status", 200, "duration_ms", 1.0)
+
+out := strings.TrimSpace(buf.String())
+var m map[string]any
+if err := json.Unmarshal([]byte(out), &m); err != nil {
+    t.Fatalf("Unmarshal: %v (out=%q)", err, out)
+}
+if _, ok := m["request_id"].(string); !ok {
+    t.Errorf("request_id missing or not string, record=%v", m)
+}
+```
+
+### `log.Fatal*` ガード (Makefile lint)
+
+`make lint` は `go vet` に加えて、`core/` 配下の非テスト `.go` ファイルに `log.Fatal` / `log.Fatalf` / `log.Fatalln` の呼び出しが新規追加されていないかを `grep` で検査する (F-12)。違反時は明示エラーで lint failure。回避策は `logger.Error(ctx, msg, err)` + `os.Exit(1)` を使うこと。
+
+### ログスキーマ契約テスト (F-16)
+
+`core/internal/logger/contract_test.go` がログスキーマの破壊的変更を検知する契約テストを提供する。検証対象は 2 系統に分かれる:
+
+| 系統             | 必須フィールド                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| HTTP 経路 (a)    | `time` / `level` / `msg` / `request_id` / `method` / `path` / `status` / `duration_ms` (型: string + number) |
+| 非 HTTP 経路 (b) | `time` / `level` / `msg` / `event_id` (型: string)                                                           |
+
+方針:
+
+- フィールドの**追加は許容** (前方互換)。既存テストは追加された属性を無視する
+- フィールドの**削除・型変更はテスト失敗**として扱う (破壊的変更検知)
+- 値の正確性 (例: `request_id` が UUID v7 か) は契約テストの対象外。別の単体テスト (`request_id` middleware 等) が個別に検証する
 
 ## go-react バックエンド (Go) のテスト
 


### PR DESCRIPTION
## 概要

設計書 #7 (M0.2 ログ・エラー基盤) のフェーズ B 最終 PR (P3)。F-16 ログスキーマ契約テストを追加し、`log.Fatal*` 禁止を Makefile lint で恒久化、規約書 (`docs/context/backend/*.md` / `docs/context/testing/backend.md`) と `core/README.md` を M0.2 のログ・エラー基盤に整合させた。

P1 (#12) / P2 (#13) のマージで完成した `core/internal/{logger,apperror,middleware}/` を契約・規約面から固定する位置付け。本 PR で M0.2 マイルストーン (#7 設計書 / 親要求) のフェーズ B が完了する。

Closes #14

## 変更内容

### コード

- `core/internal/logger/contract_test.go` (新規): F-16 契約テスト T-58〜T-62
  - HTTP 経路 (msg=access) の必須フィールド存在 + 型検証 (T-58)
  - 非 HTTP 経路の必須フィールド存在 + 型検証 (T-59)
  - 追加フィールド許容 (T-60)
  - 必須フィールド欠落で失敗 (T-61)
  - 型不一致で失敗 (T-62)
  - 数値は `encoding/json` の `float64` 前提で照合
- `core/Makefile` の `lint` target に `log.Fatal*` 検査追加 (F-12)
  - `grep -rEn --include='*.go' --exclude='*_test.go' 'log\.Fatal[a-zA-Z]*\(' .` で非テスト `.go` ファイルへの新規追加を検知
  - `grep` の exit code 2 (実行エラー) も明示的に失敗扱いに

### ドキュメント

- `core/README.md`: ログ・エラー規約節追加、`CORE_LOG_FORMAT` を環境変数表に、ディレクトリ構成を M0.2 (logger/apperror/middleware) に追従、panic 時の HTTP ステータスを 500 で明示
- `docs/context/backend/conventions.md`:
  - ロギング・テレメトリ節を詳細化 (実装スタック / 時刻 / ログレベル使い分け / 必須フィールド / context ID 伝播 / フォールバック / メッセージ言語 / ログインジェクション対策)
  - エラーハンドリング節を新設 (基本形 / `code` 命名規則 / `details` 制約 / redact 対象キー Q8 完全一覧 / panic 時の挙動)
  - middleware 構成節を新設 (D1 順序 + 各 middleware の責務)
  - Makefile 規約に `log.Fatal*` 検査を追記
- `docs/context/backend/patterns.md`:
  - middleware チェーンパターン / context ID 付与パターン / redact パターン / フォールバックパターンを新設
  - 設定読み込みパターンを `logger.Error` + `os.Exit(1)` 形に置換
  - エラーハンドリングを `apperror.New` / `WithDetails` / `Wrap` ベースに置換
- `docs/context/backend/registry.md`:
  - パッケージマッピングに `internal/logger` / `internal/apperror` / `internal/middleware` を追加
  - 環境変数表に `CORE_LOG_FORMAT` を追加
  - エラーコード一覧を新設 (`INTERNAL_ERROR`)、OIDC 標準コードとの併用方針を明記
- `docs/context/testing/backend.md`: Go (id-core) のテスト規約最低限 (標準パターン / テーブル駆動 / ログ buffer 検証 / `log.Fatal*` ガード / F-16 契約テスト) を埋め

## Codex レビュー結果

各ステップで `codex exec --sandbox read-only` に diff を渡してレビューし、ゲート (CRITICAL=0 / HIGH=0 / MEDIUM<3) を全 step で通過。

| ステップ                       | 結果                                                                            |
| ------------------------------ | ------------------------------------------------------------------------------- |
| 1. contract_test.go            | CRITICAL=0 / HIGH=0 / MEDIUM=0 / LOW=0                                          |
| 2. Makefile lint               | CRITICAL=0 / HIGH=0 / MEDIUM=1 (修正済み) / LOW=1 (GNU grep 依存、運用上許容)   |
| 3. README                      | CRITICAL=0 / HIGH=0 / MEDIUM=0 / LOW=0                                          |
| 4. context 4 ファイル          | CRITICAL=0 / HIGH=0 / MEDIUM=2 (README 含めた再照合で 5xx→500 / details? に修正) |
| 4'. README+conventions+registry | CRITICAL=0 / HIGH=0 / MEDIUM=2 (panic 5xx→500 と details 任意化を即対応)        |

詳細ログは `.ai-out/2026-05-02-p3-step{1..4,4-recheck}-codex.md` に保存。

## Test plan

- [x] `make -C core build` 成功
- [x] `make -C core test` 全 pass (`-race` 含む)
- [x] `make -C core lint` 成功 (go vet + log.Fatal* 検査)
- [x] `core/internal/logger/contract_test.go` の T-58〜T-62 が実機で全 pass
- [x] `core/Makefile` の lint が `log.Fatal*` 新規追加を検知することを試験的に確認 (注入→ lint failure → 復旧)
- [x] `grep -rEn --include='*.go' --exclude='*_test.go' 'log\.Fatal[a-zA-Z]*\(' core/` の出力が 0 件
- [x] PR description の機械的検査 (`grep -nE '(^|[^\`])@[A-Za-z0-9_-]+'`) で裸の `@` 表記なし

## バージョン変更の有無

なし。`go.mod` / `package.json` / GitHub Action の `uses` には触れていない。