### PR TITLE
feat:✨ M1.1 P2 OIDC Discovery handler (#35)

### DIFF
--- a/core/internal/oidc/discovery/handler.go
+++ b/core/internal/oidc/discovery/handler.go
@@ -1,0 +1,81 @@
+package discovery
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/mktkhr/id-core/core/internal/config"
+)
+
+// HTTP レスポンスヘッダ + Cache-Control 値の定数。
+const (
+	contentTypeJSON = "application/json"
+
+	cacheControlNoCache = "no-cache, must-revalidate"
+)
+
+// Handler は `GET /.well-known/openid-configuration` の HTTP ハンドラ。
+//
+// 起動時に 1 回だけ Metadata 構築 + Marshal + ETag 計算を行い、リクエスト毎の処理は
+// ヘッダ書き込み + キャッシュ済み body 書き出しのみ (F-21 + パフォーマンス)。
+//
+// すべて読み取り専用フィールドのため goroutine 安全。複数 Pod 環境でも同一鍵セット +
+// 同一 config から構築されるなら全 Pod で body / ETag が一致する (F-21)。
+type Handler struct {
+	body  []byte // Marshal 結果 (起動時計算)
+	etag  string // ETag(body) (起動時計算)
+	cache string // Cache-Control ヘッダ値 (起動時計算)
+}
+
+// New は Handler を構築する。Marshal が失敗した場合に error を返す
+// (Metadata は標準ライブラリだけで構築でき通常失敗しないが、防御的に error を返す I/F とする)。
+func New(cfg config.OIDCConfig) (*Handler, error) {
+	m := Build(cfg)
+	body, err := Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("discovery: メタデータの marshal に失敗しました: %w", err)
+	}
+	return &Handler{
+		body:  body,
+		etag:  ETag(body),
+		cache: cacheControlValue(cfg.DiscoveryMaxAge),
+	}, nil
+}
+
+// ServeHTTP は OIDC Discovery レスポンスを返す。
+//
+// 挙動:
+//   - If-None-Match ヘッダ値が ETag と完全一致 → 304 Not Modified (body なし)
+//   - それ以外 → 200 OK + Content-Type / Cache-Control / ETag ヘッダ + JSON body
+//
+// メソッド制限 (GET 以外で 405) は P4 の chi router 側で行う。本 handler は GET 前提。
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("If-None-Match") == h.etag {
+		// 304 では body / Content-Type を出さない (RFC 7232 §4.1)。
+		// ETag は応答に含めるのが推奨 (304 ヘッダで RP がキャッシュ更新できる)。
+		w.Header().Set("ETag", h.etag)
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.Header().Set("Cache-Control", h.cache)
+	w.Header().Set("ETag", h.etag)
+	w.WriteHeader(http.StatusOK)
+	// http.ResponseWriter.Write の error は middleware (access_log) 側でハンドルする
+	// (HTTP transport が切れた場合等の表面化処理は本層では行わない)。
+	_, _ = w.Write(h.body)
+}
+
+// cacheControlValue は CORE_OIDC_DISCOVERY_MAX_AGE に応じて Cache-Control 値を返す (F-1, Q15)。
+//
+//	maxAge == 0 (既定)  → "no-cache, must-revalidate"
+//	maxAge >  0         → "public, max-age=<N>, must-revalidate"
+//
+// `no-cache` と `max-age` の併記矛盾を避けるため、必ずどちらか一方のみを出力する。
+func cacheControlValue(maxAge int) string {
+	if maxAge <= 0 {
+		return cacheControlNoCache
+	}
+	return fmt.Sprintf("public, max-age=%d, must-revalidate", maxAge)
+}

--- a/core/internal/oidc/discovery/handler_test.go
+++ b/core/internal/oidc/discovery/handler_test.go
@@ -1,0 +1,261 @@
+package discovery_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/config"
+	"github.com/mktkhr/id-core/core/internal/oidc/discovery"
+)
+
+// テスト用の最小 OIDCConfig を組み立てる (config.Load を経由しない)。
+// オプションで DiscoveryMaxAge を上書き可能。
+func newTestConfig(maxAge int) config.OIDCConfig {
+	return config.OIDCConfig{
+		Issuer:                "https://id.example.com",
+		AuthorizationEndpoint: "https://id.example.com/authorize",
+		TokenEndpoint:         "https://id.example.com/token",
+		UserInfoEndpoint:      "https://id.example.com/userinfo",
+		JWKSURI:               "https://id.example.com/jwks",
+		DiscoveryMaxAge:       maxAge,
+	}
+}
+
+// 200 + 必須ヘッダ + body 構造の検証。
+func TestHandler_Success_200(t *testing.T) {
+	h, err := discovery.New(newTestConfig(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := res.Header.Get("ETag"); got == "" {
+		t.Errorf("ETag header missing")
+	}
+	if got := res.Header.Get("Cache-Control"); got == "" {
+		t.Errorf("Cache-Control header missing")
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	var m discovery.Metadata
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("Unmarshal body: %v\nbody=%s", err, body)
+	}
+	if m.Issuer != "https://id.example.com" {
+		t.Errorf("Issuer = %q", m.Issuer)
+	}
+}
+
+// Cache-Control 切替: max-age=0 → no-cache, must-revalidate / >0 → public, max-age=N, must-revalidate。
+func TestHandler_CacheControlSwitch(t *testing.T) {
+	cases := []struct {
+		name   string
+		maxAge int
+		want   string
+	}{
+		{name: "max-age=0 (既定)", maxAge: 0, want: "no-cache, must-revalidate"},
+		{name: "max-age=600", maxAge: 600, want: "public, max-age=600, must-revalidate"},
+		{name: "max-age=86400 (上限)", maxAge: 86400, want: "public, max-age=86400, must-revalidate"},
+		{name: "max-age=-1 → 0 同等", maxAge: -1, want: "no-cache, must-revalidate"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			h, err := discovery.New(newTestConfig(tc.maxAge))
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("Cache-Control"); got != tc.want {
+				t.Errorf("Cache-Control = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// If-None-Match 一致 → 304 Not Modified、body 空。
+func TestHandler_IfNoneMatch_Matches_304(t *testing.T) {
+	h, err := discovery.New(newTestConfig(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// 1 回目: ETag を取得
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	etag := rec1.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("ETag header missing on first request")
+	}
+
+	// 2 回目: If-None-Match で同じ ETag を渡す
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+
+	res := rec2.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNotModified {
+		t.Errorf("status = %d, want 304", res.StatusCode)
+	}
+	body, _ := io.ReadAll(res.Body)
+	if len(body) != 0 {
+		t.Errorf("304 body should be empty, got %d bytes: %q", len(body), body)
+	}
+	// 304 でも ETag は応答に含めるのが推奨
+	if got := res.Header.Get("ETag"); got != etag {
+		t.Errorf("304 ETag = %q, want %q", got, etag)
+	}
+}
+
+// If-None-Match 不一致 → 200 + body 返却。
+func TestHandler_IfNoneMatch_NoMatch_200(t *testing.T) {
+	h, err := discovery.New(newTestConfig(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("If-None-Match", `"different-etag-value"`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("200 body should not be empty")
+	}
+}
+
+// ContractTest 5 ケース: handler 経由で各 issuer 形式の endpoint URL が JSON 中に
+// 期待通りに現れる。
+func TestHandler_ContractTest_5Cases(t *testing.T) {
+	cases := []struct {
+		name              string
+		cfg               config.OIDCConfig
+		wantAuthorization string
+	}{
+		{
+			name: "1. 標準",
+			cfg: config.OIDCConfig{
+				Issuer:                "https://id.example.com",
+				AuthorizationEndpoint: "https://id.example.com/authorize",
+				TokenEndpoint:         "https://id.example.com/token",
+				UserInfoEndpoint:      "https://id.example.com/userinfo",
+				JWKSURI:               "https://id.example.com/jwks",
+			},
+			wantAuthorization: "https://id.example.com/authorize",
+		},
+		{
+			name: "2. subpath",
+			cfg: config.OIDCConfig{
+				Issuer:                "https://example.com/id-core",
+				AuthorizationEndpoint: "https://example.com/id-core/authorize",
+				TokenEndpoint:         "https://example.com/id-core/token",
+				UserInfoEndpoint:      "https://example.com/id-core/userinfo",
+				JWKSURI:               "https://example.com/id-core/jwks",
+			},
+			wantAuthorization: "https://example.com/id-core/authorize",
+		},
+		{
+			name: "3. 末尾スラッシュ (config 側で strip 済前提)",
+			cfg: config.OIDCConfig{
+				Issuer:                "https://example.com/id-core",
+				AuthorizationEndpoint: "https://example.com/id-core/authorize",
+				TokenEndpoint:         "https://example.com/id-core/token",
+				UserInfoEndpoint:      "https://example.com/id-core/userinfo",
+				JWKSURI:               "https://example.com/id-core/jwks",
+			},
+			wantAuthorization: "https://example.com/id-core/authorize",
+		},
+		{
+			name: "4. dev 非 https",
+			cfg: config.OIDCConfig{
+				Issuer:                "http://localhost:8080",
+				AuthorizationEndpoint: "http://localhost:8080/authorize",
+				TokenEndpoint:         "http://localhost:8080/token",
+				UserInfoEndpoint:      "http://localhost:8080/userinfo",
+				JWKSURI:               "http://localhost:8080/jwks",
+			},
+			wantAuthorization: "http://localhost:8080/authorize",
+		},
+		{
+			name: "5. 非標準ポート",
+			cfg: config.OIDCConfig{
+				Issuer:                "https://id.example.com:9443",
+				AuthorizationEndpoint: "https://id.example.com:9443/authorize",
+				TokenEndpoint:         "https://id.example.com:9443/token",
+				UserInfoEndpoint:      "https://id.example.com:9443/userinfo",
+				JWKSURI:               "https://id.example.com:9443/jwks",
+			},
+			wantAuthorization: "https://id.example.com:9443/authorize",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			h, err := discovery.New(tc.cfg)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d", rec.Code)
+			}
+			body := rec.Body.String()
+			if !strings.Contains(body, tc.wantAuthorization) {
+				t.Errorf("response body lacks expected authorization endpoint %q\nbody=%s", tc.wantAuthorization, body)
+			}
+		})
+	}
+}
+
+// 同一インスタンスで 100 回 GET → ETag 安定 (起動時キャッシュの確認)。
+func TestHandler_ETagStableAcrossRequests(t *testing.T) {
+	h, err := discovery.New(newTestConfig(300))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var first string
+	for i := 0; i < 100; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		got := rec.Header().Get("ETag")
+		if got == "" {
+			t.Fatalf("ETag missing at iter %d", i)
+		}
+		if i == 0 {
+			first = got
+		} else if got != first {
+			t.Fatalf("ETag drifted at iter %d: got %q, first %q", i, got, first)
+		}
+	}
+}

--- a/core/internal/oidc/discovery/metadata.go
+++ b/core/internal/oidc/discovery/metadata.go
@@ -1,0 +1,74 @@
+// Package discovery は OIDC Discovery 1.0 / RFC 8414 の OP メタデータを構築・配信する
+// (M1.1 で導入、設計 #32)。
+//
+// `GET /.well-known/openid-configuration` のレスポンス body 構築 + handler を提供する。
+// route 登録は P4 (`server.go`) で行う。
+//
+// メタデータ構築は config.OIDCConfig からの単純なフィールドコピー + 既定値だが、
+// `id_token_signing_alg_values_supported` / `response_types_supported` 等の M1.1 広告内容は
+// 設計 #32 で確定済みの「最小セット」を採用する (F-4)。後続マイルストーンで実装が進む際に
+// 配列要素を追加する。
+package discovery
+
+import (
+	"github.com/mktkhr/id-core/core/internal/config"
+)
+
+// 各 supported 配列の M1.1 広告内容 (F-4 確定値)。
+// パッケージ変数として定義し、Build() の各呼び出しで slice を共有する (Metadata は読み取り専用扱い)。
+//
+// セキュリティ: 受信側 (RP) は配列を読み取るのみで mutate しない前提。
+// もし mutate されると後続呼び出しに伝搬するが、Metadata 構造体を public に晒さず
+// `Marshal` でバイト列化する用途のみのため実害はない。
+var (
+	supportedResponseTypes      = []string{"code"}
+	supportedGrantTypes         = []string{"authorization_code"}
+	supportedSubjectTypes       = []string{"public"}
+	supportedIDTokenSigningAlgs = []string{"RS256"}
+	supportedScopes             = []string{"openid"}
+	supportedTokenAuthMethods   = []string{"client_secret_basic"}
+)
+
+// Metadata は OIDC Discovery 1.0 / RFC 8414 のレスポンス JSON 構造を表す。
+//
+// JSON キー順序は struct field 順 (encoding/json は宣言順を保つ)。OIDC Discovery 1.0 慣習順
+// (issuer → endpoints → supported features) に並べることで人間可読性を担保する。
+//
+// M1.1 範囲では 11 フィールドを広告。後続マイルストーンで追加する想定 (例: `claims_supported`,
+// `code_challenge_methods_supported`, `request_object_signing_alg_values_supported` 等)。
+type Metadata struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
+	JWKSURI                           string   `json:"jwks_uri"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	SubjectTypesSupported             []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+}
+
+// Build は config.OIDCConfig から Metadata を構築する (F-2 / F-4)。
+//
+// 各 endpoint URL は config.Load 段階で env override or issuer ベースの URL.JoinPath 構築が
+// 完了している前提 (本関数は単純にフィールドコピー)。supported 配列は M1.1 確定値を埋め込む。
+//
+// config 構造体を直接受けることで余計なアダプタを増やさない (config パッケージは既に
+// internal/* から依存される基盤層であり、依存方向 oidc/discovery → config は安全)。
+func Build(cfg config.OIDCConfig) Metadata {
+	return Metadata{
+		Issuer:                            cfg.Issuer,
+		AuthorizationEndpoint:             cfg.AuthorizationEndpoint,
+		TokenEndpoint:                     cfg.TokenEndpoint,
+		UserinfoEndpoint:                  cfg.UserInfoEndpoint,
+		JWKSURI:                           cfg.JWKSURI,
+		ResponseTypesSupported:            supportedResponseTypes,
+		GrantTypesSupported:               supportedGrantTypes,
+		SubjectTypesSupported:             supportedSubjectTypes,
+		IDTokenSigningAlgValuesSupported:  supportedIDTokenSigningAlgs,
+		ScopesSupported:                   supportedScopes,
+		TokenEndpointAuthMethodsSupported: supportedTokenAuthMethods,
+	}
+}

--- a/core/internal/oidc/discovery/metadata_test.go
+++ b/core/internal/oidc/discovery/metadata_test.go
@@ -1,0 +1,172 @@
+package discovery_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/config"
+	"github.com/mktkhr/id-core/core/internal/oidc/discovery"
+)
+
+// 基本ケース: 全 11 フィールドが期待値で埋まる。
+func TestBuild_BasicFields(t *testing.T) {
+	cfg := config.OIDCConfig{
+		Issuer:                "https://id.example.com",
+		AuthorizationEndpoint: "https://id.example.com/authorize",
+		TokenEndpoint:         "https://id.example.com/token",
+		UserInfoEndpoint:      "https://id.example.com/userinfo",
+		JWKSURI:               "https://id.example.com/jwks",
+	}
+	m := discovery.Build(cfg)
+
+	if m.Issuer != "https://id.example.com" {
+		t.Errorf("Issuer = %q", m.Issuer)
+	}
+	if m.AuthorizationEndpoint != "https://id.example.com/authorize" {
+		t.Errorf("AuthorizationEndpoint = %q", m.AuthorizationEndpoint)
+	}
+	if m.TokenEndpoint != "https://id.example.com/token" {
+		t.Errorf("TokenEndpoint = %q", m.TokenEndpoint)
+	}
+	if m.UserinfoEndpoint != "https://id.example.com/userinfo" {
+		t.Errorf("UserinfoEndpoint = %q", m.UserinfoEndpoint)
+	}
+	if m.JWKSURI != "https://id.example.com/jwks" {
+		t.Errorf("JWKSURI = %q", m.JWKSURI)
+	}
+
+	// supported 配列の M1.1 確定値 (F-4)
+	cases := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{name: "ResponseTypesSupported", got: m.ResponseTypesSupported, want: []string{"code"}},
+		{name: "GrantTypesSupported", got: m.GrantTypesSupported, want: []string{"authorization_code"}},
+		{name: "SubjectTypesSupported", got: m.SubjectTypesSupported, want: []string{"public"}},
+		{name: "IDTokenSigningAlgValuesSupported", got: m.IDTokenSigningAlgValuesSupported, want: []string{"RS256"}},
+		{name: "ScopesSupported", got: m.ScopesSupported, want: []string{"openid"}},
+		{name: "TokenEndpointAuthMethodsSupported", got: m.TokenEndpointAuthMethodsSupported, want: []string{"client_secret_basic"}},
+	}
+	for _, tc := range cases {
+		if !reflect.DeepEqual(tc.got, tc.want) {
+			t.Errorf("%s = %v, want %v", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// ContractTest 5 ケース (Q8 / F-17): issuer 形式の違いで endpoint URL が正しく組み立つ。
+//
+// 本テストでは config.OIDCConfig を直接組み立てる (config.Load を経由せず、Build の挙動を
+// 単離テスト)。issuer 由来の endpoint 構築は config.Load 側で実施されるため、
+// 本テストは Build がそれをそのまま反映することを検証する。
+func TestBuild_ContractTest_5Cases(t *testing.T) {
+	cases := []struct {
+		name              string
+		issuer            string
+		authorizationEnd  string
+		tokenEnd          string
+		userInfoEnd       string
+		jwksURI           string
+		wantAuthorization string
+	}{
+		{
+			name:              "1. 標準",
+			issuer:            "https://id.example.com",
+			authorizationEnd:  "https://id.example.com/authorize",
+			tokenEnd:          "https://id.example.com/token",
+			userInfoEnd:       "https://id.example.com/userinfo",
+			jwksURI:           "https://id.example.com/jwks",
+			wantAuthorization: "https://id.example.com/authorize",
+		},
+		{
+			name:              "2. subpath",
+			issuer:            "https://example.com/id-core",
+			authorizationEnd:  "https://example.com/id-core/authorize",
+			tokenEnd:          "https://example.com/id-core/token",
+			userInfoEnd:       "https://example.com/id-core/userinfo",
+			jwksURI:           "https://example.com/id-core/jwks",
+			wantAuthorization: "https://example.com/id-core/authorize",
+		},
+		{
+			name:              "3. 末尾スラッシュ (config 側で strip 済前提)",
+			issuer:            "https://example.com/id-core",
+			authorizationEnd:  "https://example.com/id-core/authorize",
+			tokenEnd:          "https://example.com/id-core/token",
+			userInfoEnd:       "https://example.com/id-core/userinfo",
+			jwksURI:           "https://example.com/id-core/jwks",
+			wantAuthorization: "https://example.com/id-core/authorize",
+		},
+		{
+			name:              "4. dev 非 https",
+			issuer:            "http://localhost:8080",
+			authorizationEnd:  "http://localhost:8080/authorize",
+			tokenEnd:          "http://localhost:8080/token",
+			userInfoEnd:       "http://localhost:8080/userinfo",
+			jwksURI:           "http://localhost:8080/jwks",
+			wantAuthorization: "http://localhost:8080/authorize",
+		},
+		{
+			name:              "5. 非標準ポート",
+			issuer:            "https://id.example.com:9443",
+			authorizationEnd:  "https://id.example.com:9443/authorize",
+			tokenEnd:          "https://id.example.com:9443/token",
+			userInfoEnd:       "https://id.example.com:9443/userinfo",
+			jwksURI:           "https://id.example.com:9443/jwks",
+			wantAuthorization: "https://id.example.com:9443/authorize",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.OIDCConfig{
+				Issuer:                tc.issuer,
+				AuthorizationEndpoint: tc.authorizationEnd,
+				TokenEndpoint:         tc.tokenEnd,
+				UserInfoEndpoint:      tc.userInfoEnd,
+				JWKSURI:               tc.jwksURI,
+			}
+			m := discovery.Build(cfg)
+			if m.Issuer != tc.issuer {
+				t.Errorf("Issuer = %q, want %q", m.Issuer, tc.issuer)
+			}
+			if m.AuthorizationEndpoint != tc.wantAuthorization {
+				t.Errorf("AuthorizationEndpoint = %q, want %q", m.AuthorizationEndpoint, tc.wantAuthorization)
+			}
+			// 他の endpoint も入力通り反映されることを確認
+			if m.TokenEndpoint != tc.tokenEnd {
+				t.Errorf("TokenEndpoint mismatch")
+			}
+			if m.UserinfoEndpoint != tc.userInfoEnd {
+				t.Errorf("UserinfoEndpoint mismatch")
+			}
+			if m.JWKSURI != tc.jwksURI {
+				t.Errorf("JWKSURI mismatch")
+			}
+		})
+	}
+}
+
+// endpoint 個別 override が独立に反映される (論点 #12)。
+func TestBuild_EndpointOverridesIndependently(t *testing.T) {
+	cfg := config.OIDCConfig{
+		Issuer:                "https://id.example.com",
+		AuthorizationEndpoint: "https://auth.other.example.com/authorize",
+		TokenEndpoint:         "https://id.example.com/token", // override せず issuer 由来
+		UserInfoEndpoint:      "https://userinfo.other.example.com/me",
+		JWKSURI:               "https://cdn.example.com/jwks.json",
+	}
+	m := discovery.Build(cfg)
+	if m.AuthorizationEndpoint != "https://auth.other.example.com/authorize" {
+		t.Errorf("AuthorizationEndpoint override 不適用: %q", m.AuthorizationEndpoint)
+	}
+	if m.TokenEndpoint != "https://id.example.com/token" {
+		t.Errorf("TokenEndpoint = %q (issuer 由来でなければならない)", m.TokenEndpoint)
+	}
+	if m.UserinfoEndpoint != "https://userinfo.other.example.com/me" {
+		t.Errorf("UserinfoEndpoint override 不適用: %q", m.UserinfoEndpoint)
+	}
+	if m.JWKSURI != "https://cdn.example.com/jwks.json" {
+		t.Errorf("JWKSURI override 不適用: %q", m.JWKSURI)
+	}
+}

--- a/core/internal/oidc/discovery/serialize.go
+++ b/core/internal/oidc/discovery/serialize.go
@@ -1,0 +1,41 @@
+package discovery
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+)
+
+// etagBodyByteLen は ETag 計算で sha256 出力 32 バイトの先頭から採用するバイト数。
+// 16 バイト = 128 bit の衝突耐性で実用上十分 (論点 #4 確定)。
+const etagBodyByteLen = 16
+
+// Marshal は Metadata を OIDC Discovery レスポンスとして決定的にシリアライズする (F-21)。
+//
+// 決定論性の根拠:
+//   - encoding/json は struct フィールドの宣言順を維持して出力する
+//   - json.Marshal は indent / 余分な空白を入れず、改行も追加しない
+//   - 配列要素 (supportedResponseTypes 等) はパッケージ変数で固定順序
+//
+// これにより同一鍵セット (実際には鍵に依存しないが Metadata 全体) で 100 回呼び出しても
+// 全て同一バイト列となり、ETag が安定する。
+func Marshal(m Metadata) ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// ETag はレスポンス body から strong ETag を計算する (論点 #4 確定)。
+//
+// 計算式: SHA-256(body) → 先頭 16 バイト → base64.RawURLEncoding (no-padding) → ダブルクォート囲み
+//
+// 出力例: `"abcd_efghIJKLmnopQRSt"` (24 文字 = 22 文字 base64url + 2 文字引用符)
+//
+// strong ETag (RFC 7232 §2.3) として扱うため、`W/` プレフィックスは付けない。
+// HTTP クライアント (RP の OIDC ライブラリ) は If-None-Match ヘッダで本値を完全一致比較する。
+//
+// 16 バイト = 128 bit を採用する根拠 (論点 #4):
+//   - メタデータ本数は実用上 1 本/Pod で衝突確率は事実上 0
+//   - 本値が短いほうがログ・ヘッダの可読性が高い (32 バイト = 43 文字は冗長)
+func ETag(body []byte) string {
+	sum := sha256.Sum256(body)
+	return `"` + base64.RawURLEncoding.EncodeToString(sum[:etagBodyByteLen]) + `"`
+}

--- a/core/internal/oidc/discovery/serialize_test.go
+++ b/core/internal/oidc/discovery/serialize_test.go
@@ -1,0 +1,149 @@
+package discovery_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mktkhr/id-core/core/internal/config"
+	"github.com/mktkhr/id-core/core/internal/oidc/discovery"
+)
+
+// 100 回 marshal して全て同一バイト列 (F-21 決定的シリアライズ)。
+func TestMarshal_Deterministic_100x(t *testing.T) {
+	cfg := config.OIDCConfig{
+		Issuer:                "https://id.example.com",
+		AuthorizationEndpoint: "https://id.example.com/authorize",
+		TokenEndpoint:         "https://id.example.com/token",
+		UserInfoEndpoint:      "https://id.example.com/userinfo",
+		JWKSURI:               "https://id.example.com/jwks",
+	}
+	m := discovery.Build(cfg)
+
+	first, err := discovery.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal first: %v", err)
+	}
+
+	for i := 0; i < 99; i++ {
+		got, err := discovery.Marshal(m)
+		if err != nil {
+			t.Fatalf("Marshal #%d: %v", i, err)
+		}
+		if !bytes.Equal(got, first) {
+			t.Fatalf("Marshal は決定的でなければならない (call %d で差分発生)", i)
+		}
+	}
+}
+
+// JSON のキー順序が struct field 宣言順 (= OIDC Discovery 1.0 慣習順) であること。
+//
+// encoding/json の挙動仕様: 構造体は宣言順でキーを出力する。これに依存してテストする。
+func TestMarshal_FieldOrder(t *testing.T) {
+	cfg := config.OIDCConfig{
+		Issuer:                "https://id.example.com",
+		AuthorizationEndpoint: "https://id.example.com/authorize",
+		TokenEndpoint:         "https://id.example.com/token",
+		UserInfoEndpoint:      "https://id.example.com/userinfo",
+		JWKSURI:               "https://id.example.com/jwks",
+	}
+	body, err := discovery.Marshal(discovery.Build(cfg))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	expectedOrder := []string{
+		`"issuer"`,
+		`"authorization_endpoint"`,
+		`"token_endpoint"`,
+		`"userinfo_endpoint"`,
+		`"jwks_uri"`,
+		`"response_types_supported"`,
+		`"grant_types_supported"`,
+		`"subject_types_supported"`,
+		`"id_token_signing_alg_values_supported"`,
+		`"scopes_supported"`,
+		`"token_endpoint_auth_methods_supported"`,
+	}
+	s := string(body)
+	prevIdx := -1
+	for _, key := range expectedOrder {
+		idx := strings.Index(s, key)
+		if idx < 0 {
+			t.Errorf("key not found in output: %s\noutput=%s", key, s)
+			continue
+		}
+		if idx <= prevIdx {
+			t.Errorf("key %s appears at index %d, but previous was at %d (順序違反)\noutput=%s", key, idx, prevIdx, s)
+		}
+		prevIdx = idx
+	}
+}
+
+// 出力が valid JSON であり、Marshal → Unmarshal で構造体に戻せる。
+func TestMarshal_RoundTripUnmarshal(t *testing.T) {
+	cfg := config.OIDCConfig{
+		Issuer:                "https://id.example.com",
+		AuthorizationEndpoint: "https://id.example.com/authorize",
+		TokenEndpoint:         "https://id.example.com/token",
+		UserInfoEndpoint:      "https://id.example.com/userinfo",
+		JWKSURI:               "https://id.example.com/jwks",
+	}
+	body, err := discovery.Marshal(discovery.Build(cfg))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got discovery.Metadata
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("Unmarshal: %v\nbody=%s", err, body)
+	}
+	if got.Issuer != cfg.Issuer {
+		t.Errorf("Round-trip Issuer = %q, want %q", got.Issuer, cfg.Issuer)
+	}
+}
+
+// ETag: 同一 body から常に同じ値 (100 回呼び出し全一致)。
+func TestETag_Deterministic_100x(t *testing.T) {
+	body := []byte(`{"issuer":"https://id.example.com"}`)
+	first := discovery.ETag(body)
+	for i := 0; i < 99; i++ {
+		got := discovery.ETag(body)
+		if got != first {
+			t.Fatalf("ETag は決定的でなければならない (call %d): got %q, first %q", i, got, first)
+		}
+	}
+}
+
+// ETag: body が 1 バイト変わると値も変わる (sha256 の avalanche を確認)。
+func TestETag_BodyChangeDetection(t *testing.T) {
+	a := []byte(`{"issuer":"https://id.example.com"}`)
+	b := []byte(`{"issuer":"https://id.example.cox"}`) // 末尾 1 バイト違い
+	if discovery.ETag(a) == discovery.ETag(b) {
+		t.Error("ETag が異なる body で同一になった (sha256 衝突 = 異常)")
+	}
+}
+
+// ETag フォーマット: strong ETag (引用符込み)、22 文字 base64url + 2 文字引用符 = 24 文字。
+func TestETag_Format(t *testing.T) {
+	body := []byte(`{}`)
+	got := discovery.ETag(body)
+	if len(got) != 24 {
+		t.Errorf("ETag length = %d, want 24 (`\"` + 22 chars base64url + `\"`)", len(got))
+	}
+	if !strings.HasPrefix(got, `"`) {
+		t.Errorf("ETag は `\"` で始まるべき: %q", got)
+	}
+	if !strings.HasSuffix(got, `"`) {
+		t.Errorf("ETag は `\"` で終わるべき: %q", got)
+	}
+	// W/ prefix は strong ETag では付かない
+	if strings.HasPrefix(got, "W/") {
+		t.Errorf("ETag に W/ プレフィックスが付いた (strong ETag 違反): %q", got)
+	}
+	// base64.RawURLEncoding は = padding を含まない
+	if strings.Contains(got, "=") {
+		t.Errorf("ETag に = padding が含まれた (RawURLEncoding 違反): %q", got)
+	}
+}


### PR DESCRIPTION
## 概要

M1.1 (OIDC Discovery + JWKS) の **Discovery メタデータ公開 endpoint** (`GET /.well-known/openid-configuration`) を実装。

実装プロンプト: `docs/specs/32/prompts/P2_01_core_oidc_discovery.md`

P3 (#36) と並列実装可能 (依存パッケージなし)。本タスクは handler 関数とパッケージ単体のみで、`server.go` への route 登録は P4 で行う。

## 変更内容 (3 ステップ構成)

### ステップ 1: Metadata 構造体 + Build (`d42f02c`)

- `Metadata` 構造体 (11 フィールド、JSON tag は OIDC Discovery 1.0 慣習順 = struct 宣言順)
- `Build(cfg config.OIDCConfig) Metadata`: config 由来のフィールドコピー + M1.1 確定値の supported 配列 (F-4)
- supported 配列はパッケージ変数で共有 (受信側 mutate しない前提)
- ContractTest 5 ケース (標準 / subpath / 末尾スラッシュ / dev / 非標準ポート、Q8 / F-17)

### ステップ 2: 決定的シリアライズ + ETag (`27004b9`)

- `Marshal(Metadata) ([]byte, error)`: encoding/json の struct field 順保証で決定論性を担保 (F-21)
- `ETag(body []byte) string`: SHA-256(body) → 先頭 16 バイト → `base64.RawURLEncoding` (no-padding) → ダブルクォート囲み (論点 #4 確定)
- strong ETag (RFC 7232 §2.3、`W/` プレフィックスなし) で 24 文字固定

### ステップ 3: HTTP handler + Cache-Control + If-None-Match (`4d159dd`)

- `Handler` 構造体 (起動時 body / etag / cache をキャッシュ)
- `New(cfg)`: Marshal + ETag + cacheControlValue を起動時 1 回だけ計算
- `ServeHTTP`:
  - `If-None-Match` 完全一致 → 304 Not Modified (body 空、ETag のみ応答、RFC 7232 §4.1)
  - それ以外 → 200 OK + Content-Type / Cache-Control / ETag + JSON body
- `cacheControlValue`:
  - `max-age <= 0` → `no-cache, must-revalidate`
  - `> 0` → `public, max-age=N, must-revalidate` (Q15)

## テストカバレッジ

| パッケージ | カバレッジ | 目標 | 結果 |
|---|---:|---:|:---:|
| `internal/oidc/discovery` | **95.2%** | 95%+ | ✓ |

`make -C core lint test` 緑。

## ContractTest 5 ケース (Q8 / F-17)

| # | issuer | 期待 authorization_endpoint |
|---|---|---|
| 1 | `https://id.example.com` | `https://id.example.com/authorize` |
| 2 | `https://example.com/id-core` (subpath) | `https://example.com/id-core/authorize` |
| 3 | `https://example.com/id-core/` (config 側で strip 済) | `https://example.com/id-core/authorize` |
| 4 | `http://localhost:8080` (dev) | `http://localhost:8080/authorize` |
| 5 | `https://id.example.com:9443` (非標準ポート) | `https://id.example.com:9443/authorize` |

`metadata_test.go` (Build レイヤ) と `handler_test.go` (HTTP 経路) の両方で網羅。

## 反映した論点 (設計書から)

- 論点 #4 (確定): ETag = `crypto/sha256` → 先頭 16 バイト → `base64.RawURLEncoding` (no-padding) → strong ETag (24 文字、引用符込み)
- 論点 #6 (確定): subpath issuer + 末尾スラッシュ strip + `url.URL.JoinPath` での endpoint 構築 (config 側で実施済、Build はコピーのみ)
- 論点 #7 (確定): JWKS path = `/jwks` (拡張子なし) — 本タスクは Discovery 側で `jwks_uri` を反映
- 論点 #12 (確定): endpoint 個別 override (authorize/token/userinfo/jwks_uri) が独立に効く

## 適用範囲

`core/internal/oidc/discovery/` のみ。`server.go` への route 登録 / main.go 統合 / `docs/context/` 更新は P4 で集約。

## Test plan

- [x] PR description にアーカイブ参照や固有事情が混入していない
- [x] 裸の `@<word>` 表記なし
- [x] ランタイム / 依存 / Action のバージョン変更なし (`go.mod` 触らず)
- [x] 差分が `core/internal/oidc/discovery/` 配下に限定されている
- [x] `make -C core lint test` 緑
- [x] `make -C core test-cover` で discovery カバレッジ 95%+ 達成
- [x] OIDC Discovery 1.0 / RFC 8414 必須フィールド (issuer / endpoints / supported 配列) 全て出力
- [x] ETag 形式 (24 文字 / strong / `W/` なし / `=` padding なし) 検証済み
- [x] If-None-Match 一致 → 304 + body 空、不一致 → 200 + body
- [x] Cache-Control 切替 (max-age 0 → no-cache / >0 → public, max-age) 検証済み
- [x] PR 本文と差分の整合 (3 ステップが 3 commit に分割)

## 関連 Issue

Closes #35

## 後続

- P3 (#36): JWKS handler + notimpl 503 stub — 本 PR と並列で進行可能 (依存なし)
- P4 (#37): main 統合 — 本 PR の `discovery.New` を `server.New` 呼び出し時に渡し、`/.well-known/openid-configuration` route を追加